### PR TITLE
A handful of backports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,10 @@
 {
-  "extends": [
-    "react-app"
-  ],
+  "extends": "react-app",
   "rules": {
-    "no-control-regex": 0
+    "no-control-regex": 0,
+    "@typescript-eslint/no-unused-vars": ["warn", {
+      "args": "none",
+      "varsIgnorePattern": "^_"
+    }]
   }
 }

--- a/src/components/ArtifactDetailedInfo.tsx
+++ b/src/components/ArtifactDetailedInfo.tsx
@@ -394,7 +394,7 @@ const ArtifactDetailedInfoKojiBuild: React.FC<
  */
 interface HistoryListProps {
     history: {
-        tag_listing: Array<KojiBuildTagType>;
+        tag_listing: KojiBuildTagType[];
     };
 }
 
@@ -430,7 +430,7 @@ const HistoryList: React.FC<HistoryListProps> = (props) => {
     const {
         history: { tag_listing },
     } = props;
-    const lines: Array<TagActionHistoryType> = [];
+    const lines: TagActionHistoryType[] = [];
     _.forEach(tag_listing, (e) => {
         lines.push({
             action: 'tagged into',

--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -28,7 +28,6 @@ import {
     Label,
     Button,
     FlexItem,
-    LabelProps,
     TextContent,
     DataListCell,
     DataListItem,
@@ -50,7 +49,7 @@ import {
 } from '@patternfly/react-icons';
 
 import styles from '../custom.module.css';
-import { renderStatusIcon, labelColors } from '../utils/artifactUtils';
+import { renderStatusIcon } from '../utils/artifactUtils';
 import { Artifact, StateGreenwaveType } from '../artifact';
 import { ArtifactStateProps } from './ArtifactState';
 import {
@@ -344,30 +343,6 @@ export const GreenwaveResultData: React.FC<GreenwaveResultDataProps> = (
     );
 };
 
-export const mkOutcomeLabel = (state: StateGreenwaveType) => {
-    var outcome: string | undefined = state?.result?.outcome;
-    if (_.isNil(outcome) && state.requirement?.type === 'test-result-missing') {
-        outcome = 'missed';
-    }
-    if (_.isNil(outcome)) {
-        return;
-    }
-    outcome = _.toLower(outcome);
-    const color = _.findKey(labelColors, (statuses) =>
-        _.includes(statuses, outcome),
-    );
-    return (
-        <Label
-            isCompact
-            key="outcome"
-            color={(color as LabelProps['color']) || 'grey'}
-            variant="filled"
-        >
-            {outcome}
-        </Label>
-    );
-};
-
 interface FaceForGreenwaveStateProps {
     state: StateGreenwaveType;
     artifact: Artifact;
@@ -401,15 +376,11 @@ export const FaceForGreenwaveState: React.FC<FaceForGreenwaveStateProps> = (
             </Label>,
         );
     }
-    const outcomeLabel = mkOutcomeLabel(state);
-    if (!_.isNil(outcomeLabel)) {
-        labels.push(outcomeLabel);
-    }
-    const iconName = _.get(
+    const iconName: string = _.get(
         state,
         'requirement.type',
         _.get(state, 'result.outcome', 'unknown'),
-    );
+    ).toLocaleLowerCase();
     const element = (
         <Flex style={{ minHeight: '34px' }}>
             <FlexItem>{renderStatusIcon(iconName)}</FlexItem>

--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -42,10 +42,10 @@ import {
 } from '@patternfly/react-core';
 
 import {
-    WeeblyIcon,
-    RebootingIcon,
+    RedoIcon,
     RegisteredIcon,
     OutlinedThumbsUpIcon,
+    WeeblyIcon,
 } from '@patternfly/react-icons';
 
 import styles from '../custom.module.css';
@@ -68,8 +68,7 @@ const timestampForUser = (inp: string, fromNow = false): string => {
         return time;
     }
     const passed = moment.utc(inp).local().fromNow();
-    const ret = time + ' (' + passed + ')';
-    return ret;
+    return `${time} (${passed})`;
 };
 
 interface WaiveButtonProps {
@@ -121,7 +120,7 @@ export const GreenwaveReTestButton: React.FC<GreenwaveReTestButtonProps> = (
                     e.stopPropagation();
                 }}
             >
-                <RebootingIcon />
+                <RedoIcon />
                 <span className={styles.waive}>rerun</span>
             </Button>
         </a>
@@ -176,7 +175,7 @@ export const GreenwaveResultInfo: React.FC<GreenwaveResultProps> = (props) => {
     if (_.isEmpty(pairs)) {
         return null;
     }
-    const elements: Array<JSX.Element> = _.map(pairs, ([name, value]) =>
+    const elements: JSX.Element[] = _.map(pairs, ([name, value]) =>
         mkLabel(name, value, 'orange'),
     );
     return (
@@ -219,7 +218,7 @@ export const GreenwaveWaiver: React.FC<GreenwaveWaiverProps> = (props) => {
     if (_.isEmpty(pairs)) {
         return null;
     }
-    const elements: Array<JSX.Element> = _.map(pairs, ([name, value]) =>
+    const elements: JSX.Element[] = _.map(pairs, ([name, value]) =>
         mkLabel(name, value, 'red'),
     );
     return (
@@ -241,12 +240,6 @@ export const GreenwaveWaiver: React.FC<GreenwaveWaiverProps> = (props) => {
     );
 };
 
-const reqMapping = [
-    ['requirement.scenario', 'scenario'],
-    ['requirement.source', 'source'],
-    ['requirement.error_reason', 'error reason'],
-];
-
 interface GreenwaveRequirementProps {
     state: StateGreenwaveType;
 }
@@ -258,7 +251,7 @@ export const GreenwaveRequirement: React.FC<GreenwaveRequirementProps> = (
     if (_.isEmpty(pairs)) {
         return null;
     }
-    const elements: Array<JSX.Element> = _.map(pairs, ([name, value]) =>
+    const elements: JSX.Element[] = _.map(pairs, ([name, value]) =>
         mkLabel(name, value, 'blue'),
     );
     return (
@@ -291,7 +284,7 @@ export const GreenwaveResultData: React.FC<GreenwaveResultDataProps> = (
     if (_.isUndefined(result) || !_.isObject(result?.data)) {
         return null;
     }
-    const mkItem = (name: string, values: Array<string>): JSX.Element => {
+    const mkItem = (name: string, values: string[]): JSX.Element => {
         const valuesRendered: Array<JSX.Element | string> = _.map(
             values,
             (v, index) => {
@@ -352,11 +345,11 @@ interface FaceForGreenwaveStateProps {
 export const FaceForGreenwaveState: React.FC<FaceForGreenwaveStateProps> = (
     props,
 ) => {
-    const { state, artifact, artifactDashboardUrl } = props;
-    const { waiver, requirement, result } = state;
+    const { state, artifactDashboardUrl } = props;
+    const { waiver } = state;
     const isWaived = _.isNumber(waiver?.id);
     const isGatingResult = _.isString(state.requirement?.testcase);
-    const labels: Array<JSX.Element> = [];
+    const labels: JSX.Element[] = [];
     if (isGatingResult) {
         labels.push(
             <Label
@@ -413,31 +406,24 @@ export const ArtifactGreenwaveState: React.FC<ArtifactGreenwaveStateProps> = (
     const {
         state,
         artifact,
-        stateName,
         forceExpand,
         setExpandedResult,
         artifactDashboardUrl,
     } = props;
 
-    const { requirement, result, waiver } = state;
+    const { testcase } = state;
     /*
      * Expand a specific testcase according to query string and scroll to it
      * ?focus=tc:<test-case-name> or ?focus=id:<pipeline-id>
      */
     const onToggle = () => {
-        if (!forceExpand) {
-            const key = state.testcase;
-            setExpandedResult(key);
-        } else if (forceExpand) {
-            setExpandedResult('');
-        }
+        setExpandedResult(forceExpand ? '' : testcase);
     };
     /** Note for info test results */
     const resultClasses = classnames(styles['helpSelect'], styles['level2']);
-    const key = state.testcase;
     const toRender = (
         <DataListItem
-            key={key}
+            key={testcase}
             isExpanded={forceExpand}
             className={resultClasses}
             aria-labelledby="artifact-item-result"

--- a/src/components/ArtifactKaiState.tsx
+++ b/src/components/ArtifactKaiState.tsx
@@ -24,7 +24,6 @@ import {
     Flex,
     Text,
     Alert,
-    Badge,
     Button,
     FlexItem,
     TextContent,
@@ -47,7 +46,7 @@ import {
     getTestcaseName,
     renderStatusIcon,
 } from '../utils/artifactUtils';
-import { MSG_V_1, MSG_V_0_1, BrokerMessagesType } from '../types';
+import { MSG_V_1, MSG_V_0_1 } from '../types';
 import { Artifact, StateKaiType, StateNameType } from '../artifact';
 import {
     StateDetailsEntry,
@@ -58,66 +57,16 @@ import {
 import { ArtifactStateProps } from './ArtifactState';
 import classnames from 'classnames';
 
-/**
- * 0.1.x: .label - string
- * 0.2.x: test.label - string[]
- */
-const mkLabels = (broker_msg_body: BrokerMessagesType): Array<JSX.Element> => {
-    let labels: string | Array<string> = [];
-    if (MSG_V_0_1.isMsg(broker_msg_body)) {
-        if (!broker_msg_body.label) {
-            return [];
-        }
-        labels = broker_msg_body.label;
-    }
-    if (MSG_V_1.isMsg(broker_msg_body)) {
-        if (!broker_msg_body.test.label) {
-            return [];
-        }
-        labels = broker_msg_body.test.label;
-    }
-    var labels_str: Array<string> = [];
-    if (typeof labels === 'string') {
-        /** Workaround with convert array string to array */
-        if (labels.startsWith('[')) {
-            labels_str = labels.replace(/^\[|\]$|'|\s+/g, '').split(',');
-            /** Get rid of python unicode identifier 'u' */
-            for (const key in labels_str) {
-                if (labels_str.hasOwnProperty(key))
-                    labels_str[key] = labels_str[key].substr(1);
-            }
-        } else {
-            labels_str.push(labels);
-        }
-    } else {
-        labels_str.push(...labels);
-    }
-    const components: Array<JSX.Element> = [];
-    for (const key in labels_str) {
-        if (_.has(labels_str, key)) {
-            components.push(
-                <Badge isRead key={labels_str[key]}>
-                    <TextContent>
-                        <Text component="small">{labels_str[key]}</Text>
-                    </TextContent>
-                </Badge>,
-                <>' '</>,
-            );
-        }
-    }
-    return components;
-};
-
 export interface ArtifactKaiStateProps extends ArtifactStateProps {
     state: StateKaiType;
 }
 export const ArtifactKaiState: React.FC<ArtifactKaiStateProps> = (props) => {
     const {
-        state,
         artifact,
+        artifactDashboardUrl,
         forceExpand,
         setExpandedResult,
-        artifactDashboardUrl,
+        state,
     } = props;
 
     const { broker_msg_body, kai_state } = state;
@@ -157,8 +106,8 @@ export const ArtifactKaiState: React.FC<ArtifactKaiStateProps> = (props) => {
                             key="secondary content"
                         >
                             <FaceForKaiState
-                                state={state}
                                 artifactDashboardUrl={artifactDashboardUrl}
+                                state={state}
                             />
                         </DataListCell>,
                     ]}
@@ -189,16 +138,11 @@ interface KaiStateXunitProps {
 }
 export const KaiStateXunit: React.FC<KaiStateXunitProps> = (props) => {
     const { state, artifact } = props;
-    const { broker_msg_body, kai_state } = state;
+    const { kai_state } = state;
     /* [OSCI-1861]: info messages also can have xunit */
     const stateName = kai_state.state;
     /* https://pagure.io/fedora-ci/messages/blob/master/f/schemas/test-common.yaml#_120 */
-    const showFor: Array<StateNameType> = [
-        'error',
-        'queued',
-        'running',
-        'complete',
-    ];
+    const showFor: StateNameType[] = ['error', 'queued', 'running', 'complete'];
     if (!_.includes(showFor, stateName)) {
         return null;
     }
@@ -321,7 +265,7 @@ export const KaiStateMapping: React.FC<KaiStateInfoProps> = (props) => {
     ).toString();
     //const brokerMsgUrl = `${config.datagrepper.url}/id?id=${kai_state.msg_id}&is_raw=true&size=extra-large`;
     pairs.push(['broker msg', brokerMsgUrl]);
-    const elements: Array<JSX.Element> = _.map(pairs, ([name, value]) =>
+    const elements: JSX.Element[] = _.map(pairs, ([name, value]) =>
         mkLabel(name, value, 'green'),
     );
     return (
@@ -396,11 +340,12 @@ const StageName: React.FC<StageNameProps> = (props) => {
 };
 
 interface FaceForKaiStateProps {
-    state: StateKaiType;
     artifactDashboardUrl: string;
+    state: StateKaiType;
 }
+
 const FaceForKaiState: React.FC<FaceForKaiStateProps> = (props) => {
-    const { state, artifactDashboardUrl } = props;
+    const { artifactDashboardUrl, state } = props;
     const { kai_state } = state;
     const element = (
         <Flex style={{ minHeight: '34px' }}>
@@ -410,8 +355,8 @@ const FaceForKaiState: React.FC<FaceForKaiStateProps> = (props) => {
             </Flex>
             <Flex>
                 <StateLink
-                    state={state}
                     artifactDashboardUrl={artifactDashboardUrl}
+                    state={state}
                 />
             </Flex>
         </Flex>

--- a/src/components/ArtifactKaiState.tsx
+++ b/src/components/ArtifactKaiState.tsx
@@ -37,7 +37,7 @@ import {
     DataListContent,
 } from '@patternfly/react-core';
 
-import { RebootingIcon } from '@patternfly/react-icons';
+import { RedoIcon } from '@patternfly/react-icons';
 
 import styles from '../custom.module.css';
 import { mappingDatagrepperUrl } from '../config';
@@ -236,7 +236,7 @@ export const KaiReTestButton: React.FC<KaiReTestButtonProps> = (props) => {
                     e.stopPropagation();
                 }}
             >
-                <RebootingIcon />
+                <RedoIcon />
                 <span className={styles.waive}>rerun</span>
             </Button>
         </a>

--- a/src/components/ArtifactState.tsx
+++ b/src/components/ArtifactState.tsx
@@ -34,7 +34,7 @@ import {
 
 import Linkify from 'react-linkify';
 
-import { ArrowIcon } from '@patternfly/react-icons';
+import { LinkIcon } from '@patternfly/react-icons';
 
 import {
     isKaiState,
@@ -99,14 +99,14 @@ export const StateLink: React.FC<StateLinkProps> = (props) => {
     return (
         <a
             href={href}
-            title="Result link"
+            title="Permanent link to result"
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => {
                 e.stopPropagation();
             }}
         >
-            <ArrowIcon style={{ height: '0.75em' }} />
+            <LinkIcon style={{ height: '0.9em' }} />
         </a>
     );
 };

--- a/src/components/PageByMongoField.tsx
+++ b/src/components/PageByMongoField.tsx
@@ -63,10 +63,9 @@ interface ArtifactsTableProps {
  * - embedded - used for embedded view
  * - focus - used to focus on a specific test for a single artifact view
  */
-
-const ArtifactsTable: React.FC<any> = ({
+const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
     onArtifactsLoaded,
-}: ArtifactsTableProps) => {
+}) => {
     const scrollRef = useRef<HTMLTableRowElement>(null);
     var artifacts: Artifact[] = [];
     /**
@@ -229,7 +228,7 @@ const ArtifactsTable: React.FC<any> = ({
     if (isLoading) {
         rows_loading = mkSpecialRows({
             title: 'Loading data.',
-            body: <>'Please wait.'</>,
+            body: 'Please wait.',
             type: 'loading',
         });
     }
@@ -296,7 +295,7 @@ export function PageByMongoField() {
 
     return (
         <PageCommon title={pageTitle}>
-            <ArtifactsTable />
+            <ArtifactsTable onArtifactsLoaded={onArtifactsLoaded} />
             <ToastAlertGroup />
             <WaiveForm />
         </PageCommon>

--- a/src/components/PageNewIssue.tsx
+++ b/src/components/PageNewIssue.tsx
@@ -51,9 +51,19 @@ const mkSeparatedList = (
     separator: React.ReactNode = ', ',
 ) => {
     if (_.isNil(elements)) return null;
-    return elements.reduce((acc, el) => (
-        acc === null ? el : <>{acc}{separator}{el}</>
-    ), null);
+    return elements.reduce(
+        (acc, el) =>
+            acc === null ? (
+                el
+            ) : (
+                <>
+                    {acc}
+                    {separator}
+                    {el}
+                </>
+            ),
+        null,
+    );
 };
 
 const Help = () => (
@@ -167,10 +177,10 @@ const WaiverdbInfo: React.FC = () => {
 type WaiverDBPermissionType = {
     name: string;
     description: string;
-    maintainers: Array<string>;
-    testcases: Array<string>;
-    users?: Array<string>;
-    groups?: Array<string>;
+    maintainers: string[];
+    testcases: string[];
+    users?: string[];
+    groups?: string[];
 };
 
 const WaiverdbPermissions = () => {
@@ -188,7 +198,7 @@ const WaiverdbPermissions = () => {
     if (_.isError(error)) {
         return <StackItem>{error.message}</StackItem>;
     }
-    const perms = data.waiver_db_permissions as Array<WaiverDBPermissionType>;
+    const perms = data.waiver_db_permissions as WaiverDBPermissionType[];
     const rows: IRow[] = perms.map((permission) => mkRow(permission));
     const columns: ICell[] = [
         { title: 'Test case patterns' },
@@ -220,9 +230,7 @@ const WaiverdbPermissions = () => {
 
 export function PageNewIssue() {
     return (
-        <PageCommon
-            title={`Report issue | ${config.defaultTitle}`}
-        >
+        <PageCommon title={`Report issue | ${config.defaultTitle}`}>
             <Help />
         </PageCommon>
     );

--- a/src/components/TestSuites.tsx
+++ b/src/components/TestSuites.tsx
@@ -96,6 +96,7 @@ type TestSuitePropertiesType = {
 type TestSuitePropertiesEntryType = { $: { name: string; value: string } };
 
 type TestSuiteType = {
+    _uuid: string;
     name: string;
     time?: string;
     tests: TestCaseType[];
@@ -125,7 +126,7 @@ const Testsuites: React.FC<TestsuitesProps> = (props) => {
     }
     for (const suite of xunit) {
         testsuites.push(
-            <Flex key={suite.name}>
+            <Flex key={suite._uuid}>
                 <FlexItem>
                     <TextContent>
                         <Title headingLevel="h4" size="lg">
@@ -376,9 +377,9 @@ const TestCase: React.FC<TestCaseProps> = (props) => {
         >
             <DataListItemRow>
                 <DataListToggle
-                    onClick={toggle}
-                    isExpanded={expanded}
                     id={test._uuid}
+                    isExpanded={expanded}
+                    onClick={toggle}
                 />
                 <DataListItemCells
                     className="pf-u-m-0 pf-u-p-0"
@@ -447,32 +448,30 @@ const Testsuite: React.FC<TestsuiteProps> = (props) => {
     return (
         <>
             <Flex>
-                {_.map(toggleState, (isChecked, test_case_status_name_) => {
-                    const test_case_status_name =
-                        test_case_status_name_ as TestSuiteCountNamesType;
-                    if (_.isNil(isChecked)) return <></>;
-                    return (
-                        <FlexItem key={test_case_status_name}>
-                            <Checkbox
-                                label={
-                                    <span>
-                                        {renderStatusIcon(
-                                            test_case_status_name,
-                                        )}{' '}
-                                        {suite.count[test_case_status_name]}
-                                    </span>
-                                }
-                                isChecked={_.isBoolean(isChecked) && isChecked}
-                                onChange={() =>
-                                    toggle(test_case_status_name, isChecked)
-                                }
-                                aria-label={`checkbox ${test_case_status_name}`}
-                                id={`check-${test_case_status_name}-XXX-{test._uuid}`}
-                                name={`${test_case_status_name}`}
-                            />
-                        </FlexItem>
-                    );
-                })}
+                {_.map(
+                    toggleState,
+                    (isChecked, outcome: TestSuiteCountNamesType) => {
+                        if (_.isNil(isChecked)) return <></>;
+                        const label = (
+                            <>
+                                {renderStatusIcon(outcome)}{' '}
+                                {suite.count[outcome]}
+                            </>
+                        );
+                        return (
+                            <FlexItem key={outcome}>
+                                <Checkbox
+                                    aria-label={`Toggle display of results in status ${outcome}`}
+                                    id={`check-${outcome}-${suite._uuid}`}
+                                    isChecked={isChecked}
+                                    label={label}
+                                    name={outcome}
+                                    onChange={() => toggle(outcome, isChecked)}
+                                />
+                            </FlexItem>
+                        );
+                    },
+                )}
             </Flex>
 
             <DataList aria-label="Test suite items" isCompact>

--- a/src/components/TestSuites.tsx
+++ b/src/components/TestSuites.tsx
@@ -58,49 +58,49 @@ import { renderStatusIcon } from '../utils/artifactUtils';
 import { ArtifactsXunitQuery } from '../queries/Artifacts';
 
 type TestCaseType = {
+    _uuid: string;
     name: string;
     time: string;
-    _uuid: string;
-    logs: Array<TestCaseLogsType>;
+    logs: TestCaseLogsType[];
     status: TestCaseStatusNameType;
-    phases: Array<TestCasePhasesType>;
+    phases: TestCasePhasesType[];
     message: string;
-    properties: Array<TestCasePropertiesType>;
-    'test-outputs': Array<TestCaseTestOutputsType>;
+    properties: TestCasePropertiesType[];
+    'test-outputs': TestCaseTestOutputsType[];
 };
 
-type TestCaseStatusNameType = 'pass' | 'fail' | 'skip' | 'error';
+type TestCaseStatusNameType = 'error' | 'fail' | 'pass' | 'skip';
 
-type TestCaseLogsType = { log: Array<TestCaseLogsEntryType> };
+type TestCaseLogsType = { log: TestCaseLogsEntryType[] };
 type TestCaseLogsEntryType = { $: { name: string; href: string } };
 
 type TestCaseTestOutputsType = {
-    'test-output': Array<TestCaseTestOutputsEntryType>;
+    'test-output': TestCaseTestOutputsEntryType[];
 };
 type TestCaseTestOutputsEntryType = {
     $: { result: string; remedy: string; message: string };
 };
 
-type TestCasePhasesType = { phase: Array<TestCasePhasesEntryType> };
+type TestCasePhasesType = { phase: TestCasePhasesEntryType[] };
 type TestCasePhasesEntryType = {
     $: { name: string; result: string };
-    logs: Array<TestCaseLogsType>;
+    logs: TestCaseLogsType[];
 };
 
-type TestCasePropertiesType = { property: Array<TestCasePropertiesEntryType> };
+type TestCasePropertiesType = { property: TestCasePropertiesEntryType[] };
 type TestCasePropertiesEntryType = { $: { name: string; value: string } };
 
 type TestSuitePropertiesType = {
-    property: Array<TestSuitePropertiesEntryType>;
+    property: TestSuitePropertiesEntryType[];
 };
 type TestSuitePropertiesEntryType = { $: { name: string; value: string } };
 
 type TestSuiteType = {
     name: string;
-    time: string;
-    tests: Array<TestCaseType>;
+    time?: string;
+    tests: TestCaseType[];
     status: string;
-    properties: Array<TestSuitePropertiesType>;
+    properties: TestSuitePropertiesType[];
     count: {
         pass?: number;
         fail?: number;
@@ -114,7 +114,7 @@ type TestSuiteCountType = TestSuiteType['count'];
 type TestSuiteCountNamesType = keyof TestSuiteCountType;
 
 interface TestsuitesProps {
-    xunit: Array<TestSuiteType>;
+    xunit: TestSuiteType[];
 }
 
 const Testsuites: React.FC<TestsuitesProps> = (props) => {
@@ -166,7 +166,7 @@ const mkLogName = (log: TestCaseLogsEntryType): IRow => {
 };
 
 interface TestCaseLogsProps {
-    logs: Array<TestCaseLogsType>;
+    logs: TestCaseLogsType[];
 }
 
 const TestCaseLogs: React.FC<TestCaseLogsProps> = (props) => {
@@ -175,7 +175,7 @@ const TestCaseLogs: React.FC<TestCaseLogsProps> = (props) => {
         return null;
     }
     const all_logs = logs[0].log;
-    const rows: Array<IRow> = [];
+    const rows: IRow[] = [];
     _.map(all_logs, (log) => rows.push(mkLogName(log)));
     return (
         <Table
@@ -192,12 +192,12 @@ const TestCaseLogs: React.FC<TestCaseLogsProps> = (props) => {
     );
 };
 
-const mkLogsLinks = (logs: Array<TestCaseLogsType>): JSX.Element => {
+const mkLogsLinks = (logs: TestCaseLogsType[]): JSX.Element => {
     /** logs[0].log - [log1, log2, log3] */
     if (!logs[0] || !logs[0].log) {
         return <></>;
     }
-    const links: Array<JSX.Element> = [];
+    const links: JSX.Element[] = [];
     _.map(logs[0].log, (l) =>
         links.push(
             <a
@@ -216,15 +216,15 @@ const mkLogsLinks = (logs: Array<TestCaseLogsType>): JSX.Element => {
 const mkPhase = (phase: TestCasePhasesEntryType): IRow => {
     return {
         cells: [
-            <>{renderStatusIcon(phase.$.result)}</>,
-            <>{phase.$.name}</>,
-            <>{mkLogsLinks(phase.logs)}</>,
+            renderStatusIcon(phase.$.result),
+            phase.$.name,
+            mkLogsLinks(phase.logs),
         ],
     };
 };
 
 interface TestCasePhasesProps {
-    phases: Array<TestCasePhasesType>;
+    phases: TestCasePhasesType[];
 }
 
 const TestCasePhases: React.FC<TestCasePhasesProps> = (props) => {
@@ -233,7 +233,7 @@ const TestCasePhases: React.FC<TestCasePhasesProps> = (props) => {
         return null;
     }
     const all_phases = phases[0].phase;
-    const rows: Array<IRow> = [];
+    const rows: IRow[] = [];
     _.map(all_phases, (phase) => rows.push(mkPhase(phase)));
     return (
         <Table
@@ -266,7 +266,7 @@ const mkTestOutput = (output: TestCaseTestOutputsEntryType): IRow => {
 };
 
 interface TestCaseOutputProps {
-    outputs: Array<TestCaseTestOutputsType>;
+    outputs: TestCaseTestOutputsType[];
 }
 const TestCaseOutput: React.FC<TestCaseOutputProps> = (props) => {
     const { outputs } = props;
@@ -274,7 +274,7 @@ const TestCaseOutput: React.FC<TestCaseOutputProps> = (props) => {
         return null;
     }
     const all_outputs = outputs[0]['test-output'];
-    const rows: Array<IRow> = [];
+    const rows: IRow[] = [];
     _.map(all_outputs, (output) => rows.push(mkTestOutput(output)));
     return (
         <Table
@@ -306,7 +306,7 @@ function mkProperties(property: TestCasePropertiesEntryType) {
 }
 
 interface TestCasePropertiesProps {
-    properties: Array<TestCasePropertiesType>;
+    properties: TestCasePropertiesType[];
 }
 
 const TestCaseProperties: React.FC<TestCasePropertiesProps> = (props) => {
@@ -315,7 +315,7 @@ const TestCaseProperties: React.FC<TestCasePropertiesProps> = (props) => {
         return null;
     }
     const all_properties = properties[0].property;
-    const rows: Array<IRow> = [];
+    const rows: IRow[] = [];
     _.map(all_properties, (p) => rows.push(mkProperties(p)));
     return (
         <Table
@@ -411,9 +411,7 @@ interface TestsuiteProps {
     suite: TestSuiteType;
 }
 
-type ToggleStateType = {
-    [key in TestSuiteCountNamesType]?: boolean;
-};
+type ToggleStateType = Partial<Record<TestSuiteCountNamesType, boolean>>;
 
 const default_toggle_state: ToggleStateType = {
     fail: true,
@@ -478,9 +476,9 @@ const Testsuite: React.FC<TestsuiteProps> = (props) => {
             </Flex>
 
             <DataList aria-label="Test suite items" isCompact>
-                {_.map(suite.tests, (test) => {
+                {_.map(suite.tests, (test, index) => {
                     if (toggleState[test.status]) {
-                        return <TestCase key={test.name} test={test} />;
+                        return <TestCase key={index} test={test} />;
                     }
                 })}
             </DataList>
@@ -509,7 +507,7 @@ const TestSuites_: React.FC<TestSuitesProps> = (props) => {
     const [xunitProcessed, setXunitProcessed] = useState(false);
     /** why do we need msgError? */
     const [msgError, setError] = useState<JSX.Element>();
-    const { loading, error, data } = useQuery(ArtifactsXunitQuery, {
+    const { loading, data } = useQuery(ArtifactsXunitQuery, {
         variables: {
             msg_id,
             dbFieldName1: 'aid',
@@ -525,7 +523,6 @@ const TestSuites_: React.FC<TestSuitesProps> = (props) => {
         !loading &&
         Boolean(data) &&
         _.has(data, 'artifacts.artifacts[0].states');
-    const haveErrorNoData = !loading && error && !haveData;
     useEffect(() => {
         if (!haveData) {
             return;

--- a/src/custom.module.css
+++ b/src/custom.module.css
@@ -128,11 +128,11 @@
 /*
  * Next style is used to shadow icon
  * All string up to { is a selector.
- * Selector says: 
+ * Selector says:
  * Some element above must have class .giveHint
  * Some element must have global class .pf-c-table__toggle
  * Some element must have class .pf-c-button:not(.pf-m-expanded)
- * > -- says must be follow immediatelly 
+ * > -- says must be follow immediatelly
  * Some element must be svg
  */
 .giveHint :global(.pf-c-table__toggle > .pf-c-button:not(.pf-m-expanded)) svg {

--- a/src/custom.module.css
+++ b/src/custom.module.css
@@ -111,7 +111,8 @@
  */
 :global(.pf-c-data-list__item.pf-m-expanded
         .issue_2177
-        .pf-c-data-list__toggle-icon) {
+        .pf-c-data-list__toggle-icon)
+{
     transform: none;
 }
 
@@ -123,6 +124,11 @@
 .noHint {
     border-bottom: var(--pf-c-table--border-width--base) solid
         var(--pf-global--BackgroundColor--200) !important;
+}
+
+.buildInfoCommitHash, .buildInfoTimestamp {
+    font-size: 0.85em;
+    font-family: monospace;
 }
 
 /*

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export namespace MSG_V_1 {
         scratch: boolean;
         baseline?: string;
         component: string;
-        dependencies?: Array<string>;
+        dependencies?: string[];
     };
 
     export type MsgStageType = {
@@ -109,30 +109,30 @@ export namespace MSG_V_1 {
         note?: string;
         docs?: string;
         xunit?: string;
-        label?: Array<string>;
+        label?: string[];
         category: TestCategoryType;
         lifetime?: number;
         progress?: number;
         scenario?: string;
         namespace: string;
-        xunit_urls?: Array<string>;
+        xunit_urls?: string[];
     };
 
     export type MsgTestCompleteType = {
         result: TestResultType;
         output?: string;
         runtime?: number;
-        output_urls?: Array<string>;
+        output_urls?: string[];
     };
 
     export type MsgNotificationType = {
-        recipients?: Array<string>;
+        recipients?: string[];
     };
 
     export type MsgRPMBuildTestComplete = {
         run: MsgRunType;
         test: MsgTestCommonType & MsgTestCompleteType;
-        system: Array<MsgSystemType>;
+        system: MsgSystemType[];
         version: MsgCommonType['version'];
         contact: MsgContactType;
         artifact: MsgRPMBuildType;
@@ -233,7 +233,7 @@ export namespace MSG_V_0_1 {
         ci: MsgContactType;
         run: MsgRunType;
         artifact: MsgRPMBuildType;
-        system: Array<MsgSystemType>;
+        system: MsgSystemType[];
         docs: string;
         category: TestCategoryType;
         type: string;
@@ -241,7 +241,7 @@ export namespace MSG_V_0_1 {
         status: TestResultType;
         web_url: string;
         xunit: string;
-        recipients: Array<string>;
+        recipients: string[];
         thread_id: string;
         namespace: string;
         note: string;
@@ -259,7 +259,7 @@ export namespace MSG_V_0_1 {
         label: string;
         reason: string;
         issue_url: string;
-        recipients: Array<string>;
+        recipients: string[];
         thread_id: string;
         namespace: string;
         note: string;
@@ -326,7 +326,7 @@ export namespace MSG_V_0_1 {
         scratch: boolean;
         nvr: string;
         baseline?: string;
-        dependencies?: Array<string>;
+        dependencies?: string[];
         source?: string;
     };
 
@@ -354,27 +354,27 @@ export interface SSTItem {
 }
 
 export interface SSTResult {
-	artifact: {
+    artifact: {
         id: number;
         url: string;
     };
-	assignee: string;
-	gating_bug?: {
+    assignee: string;
+    gating_bug?: {
         text: string;
         url: string;
     };
-	gating_yaml_url?: string;
-	log_urls?: string[];
-	metadata_url: string;
-	nvr: string;
-	rebuild_url?: string;
-	sortKey: string;
+    gating_yaml_url?: string;
+    log_urls?: string[];
+    metadata_url: string;
+    nvr: string;
+    rebuild_url?: string;
+    sortKey: string;
     status: string;
     tag: string;
-	testcase: {
-		category: string;
-		namespace: string;
-		type: string;
-	};
-	time: string;
+    testcase: {
+        category: string;
+        namespace: string;
+        type: string;
+    };
+    time: string;
 }

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -445,6 +445,21 @@ export const renderStatusIcon = (
     );
 };
 
+export const repoNameAndCommitFromSource = (
+    source: string,
+): [string, string | undefined] => {
+    // source.split() will always be nonempty as long as source is a string.
+    const tailSegment = _.last(source.split('rpms/'))!;
+    const [nameDotGit, commit] = tailSegment.split('#');
+    const name = nameDotGit.replace(/.git$/, '');
+    return [name, commit];
+};
+
+export const mkCommitHashFromSource = (source: string): string | undefined => {
+    const [_name, commit] = repoNameAndCommitFromSource(source);
+    return commit;
+};
+
 /**
  * Transforms
  *
@@ -452,24 +467,22 @@ export const renderStatusIcon = (
  * git://pkgs.devel.redhat.com/rpms/bash#4cbab69537d8401a4c9b3c326f25fa95c5f6f6ee
  *
  * to:
- * http://pkgs.devel.redhat.com/cgit/rpms/bash/commit/?id=13117b55f5246ecac677f8e64ea640d27a9a527d
+ * http://pkgs.devel.redhat.com/cgit/rpms/bash/commit/?id=4cbab69537d8401a4c9b3c326f25fa95c5f6f6ee
  */
 export const mkLinkPkgsDevelFromSource = (
     source: string,
     instance: KojiInstanceType,
 ) => {
-    const name_sha1 = _.last(_.split(source, 'rpms/'));
-    const [name_dot_git, sha1] = _.split(name_sha1, '#');
-    const name = _.replace(name_dot_git, /.git$/, '');
+    const [name, commit] = repoNameAndCommitFromSource(source);
     switch (instance) {
-        case 'fp':
-            return `https://src.fedoraproject.org/rpms/${name}/c/${sha1}`;
         case 'cs':
-            return `https://gitlab.com/redhat/centos-stream/rpms/${name}/-/commit/${sha1}`;
+            return `https://gitlab.com/redhat/centos-stream/rpms/${name}/-/commit/${commit}`;
+        case 'fp':
+            return `https://src.fedoraproject.org/rpms/${name}/c/${commit}`;
         case 'rh':
-            return `http://pkgs.devel.redhat.com/cgit/rpms/${name}/commit/?id=${sha1}`;
+            return `http://pkgs.devel.redhat.com/cgit/rpms/${name}/commit/?id=${commit}`;
         default:
-            console.log(`Unknown koji instance: ${instance}`);
+            console.warn(`Unknown Koji instance: ${instance}`);
             return '';
     }
 };

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -20,32 +20,27 @@
 
 import _ from 'lodash';
 import {
-    OkIcon,
-    InfoIcon,
+    CheckCircleIcon,
+    ExclamationTriangleIcon,
     GhostIcon,
-    UnlinkIcon,
-    TumblrIcon,
+    HistoryIcon,
+    InfoIcon,
     InProgressIcon,
-    TrafficLightIcon,
-    ErrorCircleOIcon,
-    PficonHistoryIcon,
-    WarningTriangleIcon,
     OutlinedQuestionCircleIcon,
+    TimesCircleIcon,
+    TrafficLightIcon,
+    UnlinkIcon,
 } from '@patternfly/react-icons';
 import { MSG_V_1, MSG_V_0_1, BrokerMessagesType } from '../types';
 import {
-    StateType,
     Artifact,
     ArtifactType,
     KaiStateType,
-    StateKaiType,
-    StageNameType,
-    StateNameType,
     KojiInstanceType,
-    StateGreenwaveType,
-    PayloadRPMBuildType,
-    PayloadMBSBuildType,
     StateGreenwaveKaiType,
+    StateGreenwaveType,
+    StateKaiType,
+    StateType,
 } from '../artifact';
 import { LabelProps } from '@patternfly/react-core';
 
@@ -334,11 +329,10 @@ export const getXunit = (broker_msg_body: BrokerMessagesType) => {
 };
 
 export const renderStatusIcon = (
-    type_: string,
+    type: string,
     mod: modifyType = 'test',
-    size = '0.75em',
+    size = '1em',
 ) => {
-    const type = _.isString(type_) ? type_.toLocaleLowerCase() : type_;
     const icons = {
         missing: {
             pick: type === 'missing' || type === 'test-result-missing',
@@ -357,7 +351,7 @@ export const renderStatusIcon = (
                 type === 'fetched-gating-yaml' ||
                 type === 'true',
             color: '--pf-global--success-color--100',
-            icon: OkIcon,
+            icon: CheckCircleIcon,
             aria: 'Result is OK.',
         },
         error: {
@@ -373,8 +367,8 @@ export const renderStatusIcon = (
                 type === 'missing-gating-yaml' ||
                 type === 'false',
             color: '--pf-global--danger-color--100',
-            icon: ErrorCircleOIcon,
-            aria: 'Result is error.',
+            icon: TimesCircleIcon,
+            aria: 'Test has failed.',
         },
         warning: {
             pick:
@@ -386,20 +380,20 @@ export const renderStatusIcon = (
                 type === 'test-result-errored-waived' ||
                 type === 'failed-fetch-gating-yaml-waived',
             color: '--pf-global--warning-color--100',
-            icon: WarningTriangleIcon,
-            aria: 'Result is warning.',
+            icon: ExclamationTriangleIcon,
+            aria: 'Test run resulted in an error.',
         },
         progress: {
             pick: type === 'running',
             color: '--pf-global--link--Color',
             icon: InProgressIcon,
-            aria: 'Result is in progress.',
+            aria: 'Test is in progress.',
         },
         history: {
             pick: type === 'queued',
             color: '--pf-global--warning-color--200',
-            icon: PficonHistoryIcon,
-            aria: 'Result has some history.',
+            icon: HistoryIcon,
+            aria: 'Test is queued.',
         },
         info: {
             pick:
@@ -414,22 +408,26 @@ export const renderStatusIcon = (
             pick: type === 'skip',
             color: '--pf-global--warning-color--200',
             icon: UnlinkIcon,
-            aria: 'Result was skipped.',
+            aria: 'Test was skipped.',
+        },
+        not_applicable: {
+            pick: type === 'not_applicable',
+            color: '--pf-global--info-color--100',
+            icon: InfoIcon,
+            aria: 'Test was skipped.',
         },
     };
     type KnownIconsType = keyof typeof icons;
     const name = _.findKey(icons, (i) => i.pick);
     if (!name) {
-        console.log('Asked to render icon wiht unknown type:', type);
+        console.warn('Asked to render icon with unknown type:', type);
         return (
             <OutlinedQuestionCircleIcon aria-label="Result is unknown type." />
         );
     }
     let useIcon = icons[name as KnownIconsType];
     let Icon = useIcon.icon;
-    if (mod === 'test') {
-        Icon = TumblrIcon;
-    } else if (mod === 'gating') {
+    if (mod === 'gating') {
         Icon = TrafficLightIcon;
     }
     const color = useIcon.color;

--- a/src/utils/artifactsTable.tsx
+++ b/src/utils/artifactsTable.tsx
@@ -338,7 +338,7 @@ export const mkArtifactRow = (artifact: Artifact): IRow => {
 };
 
 export type InputArtifactRowType = {
-    artifacts: Array<Artifact>;
+    artifacts: Artifact[];
     opened: number | null;
     queryString?: string;
     body?: JSX.Element;

--- a/src/utils/stages_states.ts
+++ b/src/utils/stages_states.ts
@@ -79,7 +79,7 @@ export const mkStagesAndStates = (
 
 const filterByStageName = (
     stage: StageNameType,
-    stageStatesArray: Array<StageNameStateNameStatesType>,
+    stageStatesArray: StageNameStateNameStatesType[],
 ) =>
     _.filter(
         stageStatesArray,
@@ -94,9 +94,7 @@ const getKaiState = (
     const s = _.find(states, ([_stageName, stateName, _states]) => {
         return _.isEqual(_.toUpper(stateNameReq), _.toUpper(stateName));
     });
-    if (_.isNil(s)) {
-        return;
-    }
+    if (_.isNil(s)) return;
     const [_stageName, _stateName, kaiStates] = s;
     var kaiState = _.find(kaiStates as StateKaiType[], (state) =>
         _.isEqual(runUrl, _.get(state.broker_msg_body, 'run.url')),
@@ -216,7 +214,7 @@ const mkReqStatesGreenwave = (
     decision: GreenwaveDecisionReplyType,
 ): StatesByCategoryType => {
     const { satisfied_requirements, unsatisfied_requirements } = decision;
-    const requirements: Array<GreenwaveRequirementType> = _.concat(
+    const requirements: GreenwaveRequirementType[] = _.concat(
         satisfied_requirements,
         unsatisfied_requirements,
     );
@@ -227,11 +225,11 @@ const mkReqStatesGreenwave = (
     _.forOwn(
         requirementsByType,
         (
-            reqsByType: Array<GreenwaveRequirementType>,
+            reqsByType: GreenwaveRequirementType[],
             reqType /* GreenwaveRequirementTypesType */,
         ) => {
             /* [r1,r2,r3] => [{req:r1}, {req:r2}, {req:r3}] */
-            const greenwaveStates: Array<StateGreenwaveType> = _.map(
+            const greenwaveStates: StateGreenwaveType[] = _.map(
                 reqsByType,
                 (req) => mkGreenwaveStateReq(req, decision),
             );
@@ -247,20 +245,18 @@ const mkResultStatesGreenwave = (
 ): StatesByCategoryType => {
     const { satisfied_requirements, unsatisfied_requirements, results } =
         decision;
-    const requirements: Array<GreenwaveRequirementType> = _.concat(
+    const requirements: GreenwaveRequirementType[] = _.concat(
         satisfied_requirements,
         unsatisfied_requirements,
     );
-    const resultsToShow: Array<GreenwaveResultType> = _.filter(
-        results,
-        (result) =>
-            _.isUndefined(
-                _.find(requirements, (req) =>
-                    _.isEqual(result.testcase.name, req.testcase),
-                ),
+    const resultsToShow: GreenwaveResultType[] = _.filter(results, (result) =>
+        _.isUndefined(
+            _.find(requirements, (req) =>
+                _.isEqual(result.testcase.name, req.testcase),
             ),
+        ),
     );
-    const resultStates: Array<StateGreenwaveType> = _.map(
+    const resultStates: StateGreenwaveType[] = _.map(
         resultsToShow,
         (res): StateGreenwaveType => ({
             testcase: res.testcase.name,
@@ -283,8 +279,8 @@ const mkStageStatesArray = (
         stage: StageNameType;
         states: StatesByCategoryType;
     }>,
-): Array<StageNameStateNameStatesType> => {
-    const stageStatesArray: Array<StageNameStateNameStatesType> = [];
+): StageNameStateNameStatesType[] => {
+    const stageStatesArray: StageNameStateNameStatesType[] = [];
     for (const { stage, states } of stageStates) {
         for (const [stateName, statesList] of _.toPairs(states)) {
             /** _.toPairs(obj) ===> [pair1, pair2, pair3] where pair == [key, value] */
@@ -299,7 +295,7 @@ const mkStageStatesArray = (
 };
 
 const mergeKaiAndGreenwaveState = (
-    stageStatesArray: Array<StageNameStateNameStatesType>,
+    stageStatesArray: StageNameStateNameStatesType[],
 ): void => {
     /**
      * Add kai state to greenwave state if both apply:
@@ -337,7 +333,7 @@ const mergeKaiAndGreenwaveState = (
 };
 
 const minimizeStagesStates = (
-    stageStatesArray: Array<StageNameStateNameStatesType>,
+    stageStatesArray: StageNameStateNameStatesType[],
 ): void => {
     /**
      * This functions applies only to case where:
@@ -347,7 +343,7 @@ const minimizeStagesStates = (
      * Remove any state in stage == 'test' if testcase appears anywhere in stage == 'greenwave'
      */
     const greenwave = filterByStageName('greenwave', stageStatesArray);
-    const greenwaveTestNames: Array<string> = [];
+    const greenwaveTestNames: string[] = [];
     _.forEach(greenwave, ([_stageName, _stateName, states]) =>
         _.forEach(states, (state) => {
             if (isGreenwaveState(state)) {
@@ -410,12 +406,12 @@ const getTestCompleteResult = (
  * To:   { error: [], queued: [], running: [], failed: [], info: [], passed: [] }
  */
 export const transformKaiStates = (
-    states: Array<StateKaiType>,
+    states: StateKaiType[],
     stage: StageNameType,
 ): StatesByCategoryType => {
     const states_by_category: StatesByCategoryType = {};
     /** statesNames: ['running', 'complete'] */
-    const statesNames: Array<StateNameType> = _.intersection<StateNameType>(
+    const statesNames: StateNameType[] = _.intersection<StateNameType>(
         _.map(
             states,
             _.flow(_.identity, _.partialRight(_.get, 'kai_state.state')),


### PR DESCRIPTION
Summary of substantial changes in this patch set:

- Switch out a couple of icons, mainly to conform with Patternfly recommendations.
- Display status icons (green check mark, red cross, etc.) in place of the letter „t“ in test results.
- Remove labels of test outcomes. These labels only duplicate in a textual form the information provided by the status icons.
- A couple of code style improvements.

Most of these changes are just ports from downstream.