### PR TITLE
Allow overriding GraphQL URL via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
-# CI dashboard for CentOS Stream, Fedora, and other builds
+# CI Dashboard for CentOS Stream, Fedora, and other builds
 
-# Code style
+[![Check build](https://github.com/fedora-ci/ciboard/actions/workflows/build.yaml/badge.svg)](https://github.com/fedora-ci/ciboard/actions/workflows/build.yaml)
 
-Google TypeScript Style Guide https://google.github.io/styleguide/tsguide.html
+## Development
+
+To run the dashboard locally on your machine, you can simply run the `npm start` command in the project directory. This will start a server on <http://localhost:3000> where you can access the dashboard frontend.
+
+The default settings asssume that the [backend](https://github.com/fedora-ci/ciboard-server/), i.e. the ciboard GraphQL server, is served on `/graphql` on the same host as the frontend. To override this URL, you can use the `REACT_APP_GRAPHQL_SERVER_URL` environment variable:
+
+    $ REACT_APP_GRAPHQL_SERVER_URL=http://localhost:5000/graphql npm start
+
+You can also use the [`.env.local` file](https://create-react-app.dev/docs/adding-custom-environment-variables/) in the project root directory to override this setting globally so that you don't have the type the long command again and again:
+
+    $ echo 'REACT_APP_GRAPHQL_SERVER_URL=http://localhost:5000/graphql' > .env.local
+    $ npm start
+
+## Code style
+
+In this project we follow the [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html).

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -36,23 +36,16 @@ import '@patternfly/react-styles/css/utilities/Sizing/sizing.css';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 import '@patternfly/react-styles/css/utilities/Text/text.css';
 
+import { config } from '../config';
 import { menuRoutes, otherRoutes } from '../routes';
 
 /**
  * By default GraphQL for query doesn't attach existing cookies.
- * GraphiQL attaches cookies to query.
- * need to instruct Gragphql to send existing cookies along with each single request.
+ * GraphQL attaches cookies to query.
+ * need to instruct GragphQL to send existing cookies along with each single request.
  */
 const httpLink = new HttpLink({
-    /**
-     * prod instance: Apollo client assumes that graphql on express side is listening on server /graphql
-     */
-    uri: '/graphql',
-    // uri: 'https://dashboard.dev.osci.redhat.com/graphql',
-    /**
-     * local development and local server can be accessed with:
-     */
-    //uri: 'http://localhost:5000/graphql',
+    uri: config.graphQlServerUrl,
     /**
      * You a making request to the same url that browser is currently on. This will add existing cookies to requests!
      */

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -21,11 +21,19 @@
 import { getOSVersionFromNvr } from './utils/artifactUtils';
 import { ArtifactType } from './artifact';
 
-/*
- *  CI Dashboard configuration file
+/**
+ * CI Dashboard global configuration.
  */
 export const config = {
     defaultTitle: 'CI Dashboard',
+    graphQlServerUrl:
+        /*
+         * By default, we assume the GraphQL server endpoint is located at `/graphql`
+         * on the same server as the frontend. For local development, one may use
+         * the internal development instance of the GraphQL server. This URL can be
+         * overriden using the `REACT_APP_GRAPHQL_SERVER_URL` environment variable.
+         */
+        process.env.REACT_APP_GRAPHQL_SERVER_URL ?? '/graphql',
     kai: {
         url: 'https://kai.osci.redhat.com',
     },


### PR DESCRIPTION
Allow developers to override the URL of the GraphQL server endpoint via the `REACT_APP_GRAPHQL_SERVER_URL` environment variable. If it's not set, default to `/graphql`.

One may use the `.env.local` file in the project root to set the variable. See the Create React App [documentation][1] for more info.

[1]: https://create-react-app.dev/docs/adding-custom-environment-variables/