### PR TITLE
Show passed test cases by default

### DIFF
--- a/src/components/TestSuites.tsx
+++ b/src/components/TestSuites.tsx
@@ -406,6 +406,21 @@ const TestSuite: React.FC<TestsuiteProps> = (props) => {
         (_value, key) =>
             Number(suite.count[key as TestSuiteCountNamesType]) > 0,
     );
+    if (
+        !_.values(initialToggleState).some((toggled) => toggled) &&
+        !_.isEmpty(initialToggleState)
+    ) {
+        /*
+         * If no items were to be displayed with the default toggle settings,
+         * toggle the first state in the list to show cases with that result.
+         * For example, it is often useful to show the passed results if no
+         * test cases failed.
+         */
+        const firstKey = _.first(_.keys(
+            initialToggleState,
+        )) as TestSuiteCountNamesType;
+        initialToggleState[firstKey] = true;
+    }
     const [toggleState, setToggleState] =
         useState<ToggleStateType>(initialToggleState);
 


### PR DESCRIPTION
This change makes it so that passed test cases are listed by default, but _only if_ all cases passed, i.e. there are no failed or errored cases.