### PR TITLE
Move detailed test results to the top

### DIFF
--- a/src/components/ArtifactGreenwaveKaiState.tsx
+++ b/src/components/ArtifactGreenwaveKaiState.tsx
@@ -206,12 +206,12 @@ export const ArtifactGreenwaveKaiState: React.FC<
                     <>
                         <GreenwaveWaiver state={state.gs} />
                         <ResultNote state={state.ks} />
-                        <GreenwaveResultInfo state={state.gs} />
-                        <KaiStateMapping artifact={artifact} state={state.ks} />
                         <KaiDetailedResults
                             artifact={artifact}
                             state={state.ks}
                         />
+                        <GreenwaveResultInfo state={state.gs} />
+                        <KaiStateMapping artifact={artifact} state={state.ks} />
                     </>
                 )}
             </DataListContent>

--- a/src/components/ArtifactKaiState.tsx
+++ b/src/components/ArtifactKaiState.tsx
@@ -391,8 +391,8 @@ export const ArtifactKaiState: React.FC<ArtifactKaiStateProps> = (props) => {
                 {forceExpand && (
                     <>
                         <ResultNote state={state} />
-                        <KaiStateMapping state={state} artifact={artifact} />
                         <KaiDetailedResults state={state} artifact={artifact} />
+                        <KaiStateMapping state={state} artifact={artifact} />
                     </>
                 )}
             </DataListContent>


### PR DESCRIPTION
Move the component for displaying detailed test results (a.k.a. xunit) to the top of the artifact result component.