### PR TITLE
Add docs button to result header

### DIFF
--- a/src/components/ArtifactGreenwaveKaiState.tsx
+++ b/src/components/ArtifactGreenwaveKaiState.tsx
@@ -38,7 +38,11 @@ import { RegisteredIcon, WeeblyIcon } from '@patternfly/react-icons';
 
 import styles from '../custom.module.css';
 import { Artifact, StateGreenwaveKaiType } from '../artifact';
-import { isResultWaivable, renderStatusIcon } from '../utils/artifactUtils';
+import {
+    getUmbDocsUrl,
+    isResultWaivable,
+    renderStatusIcon,
+} from '../utils/artifactUtils';
 import { ArtifactStateProps, StateLink } from './ArtifactState';
 import {
     GreenwaveResultInfo,
@@ -47,6 +51,7 @@ import {
 } from './ArtifactGreenwaveState';
 import {
     KaiDetailedResults,
+    KaiDocsButton,
     KaiRerunButton,
     KaiStateMapping,
     ResultNote,
@@ -61,10 +66,11 @@ export const GreenwaveKaiStateActions: React.FC<
     GreenwaveKaiStateActionsProps
 > = (props) => {
     const { state, artifact } = props;
+    const docsUrl = getUmbDocsUrl(state.ks.broker_msg_body);
     const rerunUrl = state.ks.broker_msg_body.run.rebuild;
     const showWaiveButton = isResultWaivable(state.gs);
     return (
-        <Flex style={{ minWidth: '15em' }}>
+        <Flex style={{ minWidth: '20em' }}>
             <Flex flex={{ default: 'flex_1' }}>
                 {showWaiveButton && (
                     <WaiveButton artifact={artifact} state={state.gs} />
@@ -72,6 +78,9 @@ export const GreenwaveKaiStateActions: React.FC<
             </Flex>
             <Flex flex={{ default: 'flex_1' }}>
                 <KaiRerunButton rerunUrl={rerunUrl} />
+            </Flex>
+            <Flex flex={{ default: 'flex_1' }}>
+                <KaiDocsButton docsUrl={docsUrl} />
             </Flex>
         </Flex>
     );

--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -57,6 +57,7 @@ import {
     isResultWaivable,
     renderStatusIcon,
     timestampForUser,
+    getGreenwaveDocsUrl,
 } from '../utils/artifactUtils';
 import { Artifact, StateGreenwaveType } from '../artifact';
 import { isResultMissing } from '../utils/artifactUtils';
@@ -68,7 +69,7 @@ import {
     mkPairs,
 } from './ArtifactState';
 import { createWaiver } from '../actions';
-import { KaiRerunButton } from './ArtifactKaiState';
+import { KaiDocsButton, KaiRerunButton } from './ArtifactKaiState';
 import { docs } from '../config';
 import { ExternalLink } from './ExternalLink';
 
@@ -111,10 +112,11 @@ export const GreenwaveStateActions: React.FC<GreenwaveStateActionsProps> = (
     props,
 ) => {
     const { artifact, state } = props;
+    const docsUrl = getGreenwaveDocsUrl(state);
     const rerunUrl = _.first(state.result?.data.rebuild);
     const showWaiveButton = isResultWaivable(state);
     return (
-        <Flex style={{ minWidth: '15em' }}>
+        <Flex style={{ minWidth: '20em' }}>
             <Flex flex={{ default: 'flex_1' }}>
                 {showWaiveButton && (
                     <WaiveButton artifact={artifact} state={state} />
@@ -122,6 +124,9 @@ export const GreenwaveStateActions: React.FC<GreenwaveStateActionsProps> = (
             </Flex>
             <Flex flex={{ default: 'flex_1' }}>
                 <KaiRerunButton rerunUrl={rerunUrl} />
+            </Flex>
+            <Flex flex={{ default: 'flex_1' }}>
+                <KaiDocsButton docsUrl={docsUrl} />
             </Flex>
         </Flex>
     );

--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -93,11 +93,12 @@ export const WaiveButton: React.FC<WaiveButtonProps> = (props) => {
     return (
         <Button
             className={resultClasses}
+            icon={<OutlinedThumbsUpIcon />}
             isSmall
             onClick={onClick}
             variant="control"
         >
-            <OutlinedThumbsUpIcon /> <span>waive</span>
+            waive
         </Button>
     );
 };
@@ -335,19 +336,16 @@ export const GreenwaveMissingHints: React.FC<{}> = (props) => (
                     </p>
                     <p>
                         Note that some of the tests are configured globally,
-                        like
-                        <code>
-                            osci.brew-build.installability.functional
-                        </code>{' '}
-                        or
-                        <code>osci.brew-build.rpmdeplint.functional</code>.
+                        like{' '}
+                        <code>osci.brew-build.installability.functional</code>{' '}
+                        or <code>osci.brew-build.rpmdeplint.functional</code>.
                         Missing tests for these are expected for older builds.
                     </p>
                 </ListItem>
                 <ListItem>
                     If this is <code>leapp.brew-build.upgrade.distro</code>{' '}
                     test, it might depend on an unfinished dependent test{' '}
-                    <code>osci.brew-build.test-compose.integration</code>.
+                    <code>osci.brew-build.compose-ci.integration</code>.
                 </ListItem>
                 <ListItem>
                     There is an outage or significant load affecting CI systems

--- a/src/components/ArtifactKaiState.tsx
+++ b/src/components/ArtifactKaiState.tsx
@@ -115,6 +115,7 @@ export const KaiRerunButton: React.FC<KaiRerunButtonProps> = (props) => {
             className={styles.actionButton}
             component="a"
             href={rerunUrl}
+            icon={<RedoIcon />}
             isSmall
             onClick={(e) => {
                 e.stopPropagation();
@@ -124,7 +125,7 @@ export const KaiRerunButton: React.FC<KaiRerunButtonProps> = (props) => {
             title="Rerun testing. Note login to the linked system might be required."
             variant="control"
         >
-            <RedoIcon style={{ height: '0.8em' }} /> <span>rerun</span>
+            rerun
         </Button>
     );
 };

--- a/src/components/ArtifactKaiState.tsx
+++ b/src/components/ArtifactKaiState.tsx
@@ -36,13 +36,13 @@ import {
     Text,
     TextContent,
 } from '@patternfly/react-core';
-
-import { RedoIcon } from '@patternfly/react-icons';
+import { BookIcon, RedoIcon } from '@patternfly/react-icons';
 
 import styles from '../custom.module.css';
 import { mappingDatagrepperUrl } from '../config';
 import { TestSuites } from './TestSuites';
 import {
+    getUmbDocsUrl,
     getTestcaseName,
     getThreadID,
     LinkifyNewTab,
@@ -101,6 +101,30 @@ export const KaiDetailedResults: React.FC<KaiDetailedResultsProps> = (
         </StateDetailsEntry>
     );
     return render;
+};
+
+export interface KaiDocsButtonProps {
+    docsUrl?: string;
+}
+
+export const KaiDocsButton: React.FC<KaiDocsButtonProps> = (props) => {
+    const { docsUrl } = props;
+    if (_.isEmpty(docsUrl)) return null;
+    return (
+        <Button
+            className={styles.actionButton}
+            component="a"
+            href={docsUrl}
+            icon={<BookIcon />}
+            isSmall
+            rel="noopener noreferrer"
+            target="_blank"
+            title="Documentation for this test provided by the CI system."
+            variant="secondary"
+        >
+            docs
+        </Button>
+    );
 };
 
 export interface KaiRerunButtonProps {
@@ -267,13 +291,16 @@ export const KaiStateMapping: React.FC<KaiStateMappingProps> = (props) => {
 
 export const KaiStateActions: React.FC<PropsWithKaiState> = (props) => {
     const { broker_msg_body } = props.state;
+    const docsUrl = getUmbDocsUrl(broker_msg_body);
     const rerunUrl = broker_msg_body.run.rebuild;
-    if (_.isEmpty(rerunUrl)) return null;
     return (
-        <Flex style={{ minWidth: '15em' }}>
+        <Flex style={{ minWidth: '20em' }}>
             <Flex flex={{ default: 'flex_1' }}></Flex>
             <Flex flex={{ default: 'flex_1' }}>
                 <KaiRerunButton rerunUrl={rerunUrl} />
+            </Flex>
+            <Flex flex={{ default: 'flex_1' }}>
+                <KaiDocsButton docsUrl={docsUrl} />
             </Flex>
         </Flex>
     );

--- a/src/custom.module.css
+++ b/src/custom.module.css
@@ -79,9 +79,9 @@
 }
 
 /* https://www.w3schools.com/cssref/css_selectors.asp */
-.actionButton:global(.pf-c-button.pf-m-control) {
-    padding-top: 0px;
-    padding-bottom: 0px;
+.actionButton:global(.pf-c-button) {
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 .pageHeaderNav {

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,6 +338,12 @@ export namespace MSG_V_0_1 {
     export function isMsg(msg: BrokerMessagesType): msg is MessagesType {
         return msg.version.startsWith('0.1.');
     }
+
+    export function resultHasDocs(
+        msg: BrokerMessagesType,
+    ): msg is MsgRPMBuildTestComplete | MsgRPMBuildTestError {
+        return _.has(msg, 'docs');
+    }
 }
 
 export type BrokerMessagesType = MSG_V_0_1.MessagesType | MSG_V_1.MessagesType;

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -38,6 +38,7 @@ import { MSG_V_1, MSG_V_0_1, BrokerMessagesType } from '../types';
 import {
     Artifact,
     ArtifactType,
+    GreenwaveResultType,
     isArtifactMBS,
     isArtifactRPM,
     KaiStateType,
@@ -211,6 +212,34 @@ export const artifactUrl = (artifact: Artifact) => {
     };
     return urlMap[artifact.type];
 };
+
+/**
+ * Extract testcase documentation URL from a UMB message.
+ * @param brokerMessage UMB message from CI system.
+ * @returns URL to documentation as provided by the CI system or `undefined`.
+ */
+export function getUmbDocsUrl(
+    brokerMessage: BrokerMessagesType,
+): string | undefined {
+    if (MSG_V_0_1.isMsg(brokerMessage)) {
+        if (MSG_V_0_1.resultHasDocs(brokerMessage)) {
+            return brokerMessage.docs;
+        }
+        return brokerMessage.ci.docs;
+    }
+    if (MSG_V_1.isMsg(brokerMessage)) {
+        return brokerMessage.test.docs;
+    }
+    return;
+}
+
+/**
+ * Extract testcase documentation URL from Greenwave server response.
+ * @param state Gating state response from Greenwave.
+ * @returns URL to documentation as provided by the CI system or `undefined`.
+ */
+export const getGreenwaveDocsUrl = (state: StateGreenwaveType) =>
+    state.result?.testcase.ref_url;
 
 export const resultColors = {
     '--pf-global--success-color--100': [


### PR DESCRIPTION
This change adds a documentation button to the header of individual test results.

Preview:

![Screenshot 2022-06-14 at 11-33-41 ✅ kernel-rt-5 14 0-85 rt21 85 el9 CI Dashboard](https://user-images.githubusercontent.com/134321/173545733-101dd97b-9001-4954-9667-09e796cdfa09.png)

Reference: OSCI-3201