### PR TITLE
Tag container images with git-tag-name

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -46,8 +46,10 @@ jobs:
         tags: |
             ${{ env.IMAGE_REGISTRY_GITHUB }}:${{ steps.vars.outputs.sha_short }}
             ${{ ( github.ref == 'refs/heads/main' && format('{0}:latest', env.IMAGE_REGISTRY_GITHUB) ) || '' }}
+            ${{ ( github.ref_type == 'tag' && format('{0}:{1}', env.IMAGE_REGISTRY_GITHUB, github.ref_name) ) || '' }}
             ${{ env.IMAGE_REGISTRY_QUAY }}:${{ steps.vars.outputs.sha_short }}
             ${{ ( github.ref == 'refs/heads/main' && format('{0}:latest', env.IMAGE_REGISTRY_QUAY) ) || '' }}
+            ${{ ( github.ref_type == 'tag' && format('{0}:{1}', env.IMAGE_REGISTRY_QUAY, github.ref_name) ) || '' }}
         containerfiles: |
           ./Dockerfile
 


### PR DESCRIPTION
To procceed with https://issues.redhat.com/browse/OSCI-3339 we need to somehow mark stable images.
This CI allows to convert git-tag to container-tags.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>