### PR TITLE
Document compose CI test RHEL9 variant

### DIFF
--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -351,7 +351,7 @@ export const GreenwaveMissingHints: React.FC<{}> = (props) => (
                     If this is <code>leapp.brew-build.upgrade.distro</code>{' '}
                     test, it might depend on an unfinished dependent test{' '}
                     <code>osci.brew-build.compose-ci.integration</code>{' '}
-                    or <code>osci.brew-build.test-compose.integration</code>{' '}.
+                    or <code>osci.brew-build.test-compose.integration</code>.
                 </ListItem>
                 <ListItem>
                     There is an outage or significant load affecting CI systems

--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -350,7 +350,8 @@ export const GreenwaveMissingHints: React.FC<{}> = (props) => (
                 <ListItem>
                     If this is <code>leapp.brew-build.upgrade.distro</code>{' '}
                     test, it might depend on an unfinished dependent test{' '}
-                    <code>osci.brew-build.compose-ci.integration</code>.
+                    <code>osci.brew-build.compose-ci.integration</code>{' '}
+                    or <code>osci.brew-build.test-compose.integration</code>{' '}.
                 </ListItem>
                 <ListItem>
                     There is an outage or significant load affecting CI systems


### PR DESCRIPTION
AFAIK the test has different name for RHEL9, document
it for better user experience.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>