### PR TITLE
Fix icon for combined results

### DIFF
--- a/src/components/ArtifactGreenwaveKaiState.tsx
+++ b/src/components/ArtifactGreenwaveKaiState.tsx
@@ -121,7 +121,8 @@ export const FaceForGreenwaveKaiState: React.FC<
     }
     const resultOutcome = state.gs.result?.outcome;
     const requimentType = state.gs.requirement?.type;
-    const iconName = _.compact([resultOutcome, requimentType, 'unknown'])[0];
+    // Prefer Greenwave's point of view over status from UMB message.
+    const iconName = requimentType || resultOutcome || 'unknown';
     return (
         <Flex>
             <Flex flex={{ default: 'flex_1' }}>

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -374,7 +374,6 @@ export function mapTypeToIconsProps(type: string): IconProps | null {
             pick:
                 type === 'failed' ||
                 type === 'fail' ||
-                type === 'test-result-errored' ||
                 type === 'failed-fetch-gating-yaml' ||
                 type === 'test-result-failed' ||
                 type === 'invalid-gating-yaml' ||
@@ -390,6 +389,7 @@ export function mapTypeToIconsProps(type: string): IconProps | null {
                 type === 'needs_inspection' ||
                 type === 'invalid-gating-yaml-waived' ||
                 type === 'missing-gating-yaml-waived' ||
+                type === 'test-result-errored' ||
                 type === 'test-result-failed-waived' ||
                 type === 'test-result-missing-waived' ||
                 type === 'test-result-errored-waived' ||


### PR DESCRIPTION
Decide which icon to show based on Greenwave's point of view preferentially. Whenver a result is failed from gating POV, show the red "failed" icon.

See also discussion in OSCI-3546.