### PR TITLE
Revert "Update helper text to rename compose-ci to test-compose"

### DIFF
--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -350,7 +350,7 @@ export const GreenwaveMissingHints: React.FC<{}> = (props) => (
                 <ListItem>
                     If this is <code>leapp.brew-build.upgrade.distro</code>{' '}
                     test, it might depend on an unfinished dependent test{' '}
-                    <code>osci.brew-build.test-compose.integration</code>{' '}
+                    <code>osci.brew-build.compose-ci.integration</code>{' '}
                     or <code>osci.brew-build.test-compose.integration</code>.
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
Reverts fedora-ci/ciboard#25

Give prio to https://github.com/fedora-ci/ciboard/pull/25
1. Both names are still used as far as I know, and
2. we now have the same name twice in a row.