### PR TITLE
Fix display of log links

### DIFF
--- a/src/components/TestSuites.tsx
+++ b/src/components/TestSuites.tsx
@@ -71,6 +71,7 @@ import {
     getProperty,
 } from '../testsuite';
 import styles from '../custom.module.css';
+import { ExternalLink } from './ExternalLink';
 
 interface TestSuitesInternalProps {
     xunit: TestSuite[];
@@ -102,14 +103,9 @@ const TestSuitesInternal: React.FC<TestSuitesInternalProps> = (props) => {
 };
 
 const mkLogLink = (log: TestCaseLogsEntry): JSX.Element => (
-    <a
-        href={log.$.href}
-        key={log.$.name}
-        rel="noopener noreferrer"
-        target="_blank"
-    >
+    <ExternalLink href={log.$.href} key={log.$.name}>
         {log.$.name}
-    </a>
+    </ExternalLink>
 );
 
 interface LogsLinksProps {

--- a/src/utils/artifactsTable.tsx
+++ b/src/utils/artifactsTable.tsx
@@ -413,7 +413,7 @@ export function mkSeparatedList(
     return elements.reduce(
         (acc, el) =>
             acc === null ? (
-                el
+                <>{el}</>
             ) : (
                 <>
                     {acc}


### PR DESCRIPTION
The `mkSeparatedList` function needs to return a fragment even if the
list only has a single element. Otherwise, the table mashes the inner
link's attributes together with the containing cell's and creates an
invalid mess, e.g.

    <td href="..." target="_blank">dmesg.log</td>

Reference: OSCI-3627