### PR TITLE
Fix display of test outputs from xunit

### DIFF
--- a/src/components/TestSuites.tsx
+++ b/src/components/TestSuites.tsx
@@ -200,8 +200,8 @@ const OutputsTable: React.FC<OutputsTableProps> = (props) => {
 
 function hasTestCaseContent(testCase: TestCase): boolean {
     return (
-        !_.isEmpty(_.get(testCase, 'phases[0].phase')) ||
-        !_.isEmpty(_.get(testCase, 'outputs[0][test-output]'))
+        !_.isEmpty(testCase.phases[0]?.phase) ||
+        !_.isEmpty(testCase['test-outputs'])
     );
 }
 


### PR DESCRIPTION
Fix display of detailed info from the `test-outputs` field from the results xunit. This bug was caused by an improper inspection of the test case results object. As a fix, use TypeScript features in place of an opaque Lodash
function to inspect objects.

Reference: OSCI-3636