### PR TITLE
Fix blank page on regexp error

### DIFF
--- a/src/components/ArtifactsListByFilters.tsx
+++ b/src/components/ArtifactsListByFilters.tsx
@@ -152,7 +152,7 @@ const ArtifactsTable: React.FC = () => {
     });
 
     /** Even there is an error there could be data */
-    const haveData = !isLoading && data && !_.isEmpty(data.artifacts.artifacts);
+    const haveData = !isLoading && data && !_.isEmpty(data.artifacts?.artifacts);
     const haveErrorNoData = !isLoading && error && !haveData;
     const aidsAtPage: string[] = [];
     if (haveData) {


### PR DESCRIPTION
Optional chaining is added for data artifacts check, to prevent uncaught error and blank page for dashboard page.

Reference: OSCI-1484