### PR TITLE
Extend build info component for MBS

### DIFF
--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -418,6 +418,7 @@ export const koji_instance = (type: ArtifactType): KojiInstanceType => {
         case 'koji-build-cs':
             return 'cs';
         case 'brew-build':
+        case 'redhat-module':
             return 'rh';
         default:
             throw new Error(`Unknown type: ${type}`);
@@ -425,7 +426,6 @@ export const koji_instance = (type: ArtifactType): KojiInstanceType => {
 };
 
 export interface CommitObject {
-    commit_message: string;
     committer_date_seconds: number;
     committer_email: string;
     committer_name: string;

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -480,3 +480,20 @@ export interface KojiBuildInfo {
 export interface KojiTaskInfo {
     builds?: KojiBuildInfo[];
 }
+
+export interface MbsTask {
+    id?: number;
+    nvr: string;
+}
+
+export interface MbsBuildInfo {
+    commit?: CommitObject;
+    id: number;
+    name: string;
+    owner: string;
+    scmurl?: string;
+    tag_history?: KojiHistory;
+    tags?: KojiBuildTag[];
+    tasks: MbsTask[];
+    time_completed?: string;
+}

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -409,7 +409,15 @@ export type ComponentComponentMappingType = {
 /**
  * GraphQL KojiInstanceInputType
  */
-export type KojiInstanceType = 'fp' | 'cs' | 'rh';
+export type KojiInstanceType = 'cs' | 'fp' | 'rh';
+/**
+ * GraphQL DistGitInstanceInputType
+ */
+export type DistGitInstanceType = KojiInstanceType;
+/**
+ * GraphQL MbsInstanceInputType
+ */
+export type MbsInstanceType = KojiInstanceType;
 
 export const koji_instance = (type: ArtifactType): KojiInstanceType => {
     switch (type) {

--- a/src/components/ArtifactDetailedInfo.tsx
+++ b/src/components/ArtifactDetailedInfo.tsx
@@ -40,6 +40,7 @@ import {
     TabTitleText,
     Tabs,
 } from '@patternfly/react-core';
+import classNames from 'classnames';
 
 import styles from '../custom.module.css';
 import { TabClickHandlerType } from '../types';
@@ -131,11 +132,18 @@ const ArtifactDetailedInfoKojiBuild: React.FC<
         if (commitTimeLocal.isValid())
             commitTimeWithTz = commitTimeLocal.format('YYYY-MM-DD HH:mm ZZ');
     }
+
+    const descListClassName = classNames(
+        'pf-u-px-lg',
+        'pf-u-py-md',
+        styles['buildInfo'],
+    );
+
     return (
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
             <Tab eventKey={0} title={<TabTitleText>Build Info</TabTitleText>}>
                 <DescriptionList
-                    className="pf-u-px-lg pf-u-py-md"
+                    className={descListClassName}
                     columnModifier={{ default: '2Col' }}
                     isAutoColumnWidths
                     isCompact

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -20,14 +20,15 @@
  */
 
 export interface ExternalLinkProps {
-    href: string;
+    className?: string;
+    href?: string;
 }
 
 export function ExternalLink(
     props: React.PropsWithChildren<ExternalLinkProps>,
 ) {
     return (
-        <a href={props.href} target="_blank" rel="noopener noreferrer">
+        <a target="_blank" rel="noopener noreferrer" {...props}>
             {props.children}
         </a>
     );

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -34,11 +34,34 @@ export const config = {
          * overriden using the `REACT_APP_GRAPHQL_SERVER_URL` environment variable.
          */
         process.env.REACT_APP_GRAPHQL_SERVER_URL ?? '/graphql',
+    greenwave: {
+        url: 'https://greenwave.engineering.redhat.com',
+    },
     kai: {
         url: 'https://kai.osci.redhat.com',
     },
-    greenwave: {
-        url: 'https://greenwave.engineering.redhat.com',
+    koji: {
+        cs: {
+            webUrl: 'https://kojihub.stream.centos.org/koji',
+        },
+        fp: {
+            webUrl: 'https://koji.fedoraproject.org/koji',
+        },
+        rh: {
+            webUrl: 'https://brewweb.engineering.redhat.com/brew',
+        },
+    },
+    mbs: {
+        cs: {
+            // CentOS Stream has no mbs-ui instance.
+            webUrl: null,
+        },
+        fp: {
+            webUrl: 'https://release-engineering.github.io/mbs-ui/',
+        },
+        rh: {
+            webUrl: 'https://mbsweb.engineering.redhat.com/',
+        },
     },
     waiverdb: {
         url: 'https://waiverdb.engineering.redhat.com',

--- a/src/custom.module.css
+++ b/src/custom.module.css
@@ -102,6 +102,10 @@
     transform: none;
 }
 
+dl.buildInfo {
+    column-gap: var(--pf-global--spacer--lg);
+}
+
 .buildInfoCommitHash,
 .buildInfoTimestamp {
     font-size: 0.85em;

--- a/src/queries/Artifacts.ts
+++ b/src/queries/Artifacts.ts
@@ -103,6 +103,30 @@ const greenwaveDecisionFragment = gql`
     }
 `;
 
+const commitInfoFragment = gql`
+    fragment CommitInfoFragment on CommitObject {
+        committer_date_seconds
+        committer_email
+        committer_name
+    }
+`;
+
+const tagHistoryFragment = gql`
+    fragment TagHistoryFragment on KojiHistoryType {
+        tag_listing {
+            tag_name
+            tag_id
+            active
+            create_ts
+            creator_id
+            creator_name
+            revoke_ts
+            revoker_id
+            revoker_name
+        }
+    }
+`;
+
 export interface ArtifactsDetailedInfoKojiTaskData {
     koji_task?: KojiTaskInfo;
 }
@@ -131,27 +155,54 @@ export const ArtifactsDetailedInfoKojiTask = gql`
                     id
                 }
                 history(instance: $koji_instance) {
-                    tag_listing {
-                        tag_name
-                        tag_id
-                        active
-                        create_ts
-                        creator_id
-                        creator_name
-                        revoke_ts
-                        revoker_id
-                        revoker_name
-                    }
+                    ...TagHistoryFragment
                 }
                 commit_obj(instance: $distgit_instance) {
-                    committer_name
-                    committer_email
-                    committer_date_seconds
-                    commit_message
+                    ...CommitInfoFragment
                 }
             }
         }
     }
+    ${commitInfoFragment}
+    ${tagHistoryFragment}
+`;
+
+export interface ArtifactsDetailedInfoModuleBuildData {
+    // TODO: Import the appropriate types from backend.
+    mbs_build?: any;
+}
+
+export const ArtifactsDetailedInfoModuleBuild = gql`
+    query ArtifactsDetailedInfoModuleBuild(
+        $build_id: Int!
+        $mbs_instance: MbsInstanceInputType
+        $koji_instance: KojiInstanceInputType
+        $distgit_instance: DistGitInstanceInputType
+    ) {
+        mbs_build(build_id: $build_id, instance: $mbs_instance) {
+            commit(instance: $distgit_instance) {
+                ...CommitInfoFragment
+            }
+            id
+            name
+            owner
+            scmurl
+            tag_history(instance: $koji_instance) {
+                ...TagHistoryFragment
+            }
+            tags(instance: $koji_instance) {
+                id
+                name
+            }
+            tasks {
+                id
+                nvr
+            }
+            time_completed
+        }
+    }
+    ${commitInfoFragment}
+    ${tagHistoryFragment}
 `;
 
 export const ArtifactsCompleteQuery = gql`

--- a/src/queries/Artifacts.ts
+++ b/src/queries/Artifacts.ts
@@ -23,6 +23,7 @@ import {
     Artifact,
     ComponentComponentMappingType,
     KojiTaskInfo,
+    MbsBuildInfo,
 } from '../artifact';
 
 const stateEntryFragment = gql`
@@ -168,8 +169,7 @@ export const ArtifactsDetailedInfoKojiTask = gql`
 `;
 
 export interface ArtifactsDetailedInfoModuleBuildData {
-    // TODO: Import the appropriate types from backend.
-    mbs_build?: any;
+    mbs_build?: MbsBuildInfo;
 }
 
 export const ArtifactsDetailedInfoModuleBuild = gql`

--- a/src/utils/artifactUtils.test.ts
+++ b/src/utils/artifactUtils.test.ts
@@ -20,7 +20,11 @@
  */
 
 import { StateGreenwaveType } from '../artifact';
-import { isResultWaivable } from './artifactUtils';
+import {
+    ScmUrlComponents,
+    isResultWaivable,
+    parseScmUrl,
+} from './artifactUtils';
 
 test('passed result is not waivable', () => {
     const grenwaveState: StateGreenwaveType = {
@@ -84,4 +88,36 @@ test('waived failed result is waivable', () => {
         },
     };
     expect(isResultWaivable(grenwaveState)).toStrictEqual(true);
+});
+
+test('parse Git URL from Brew', () => {
+    const scmUrl =
+        'git://pkgs.devel.redhat.com/rpms/bash.git#4053763aa726f25eea4c9b3cfc5f4cbab69d86f';
+    const expected: ScmUrlComponents = {
+        commit: '4053763aa726f25eea4c9b3cfc5f4cbab69d86f',
+        name: 'bash',
+        namespace: 'rpms',
+    };
+    expect(parseScmUrl(scmUrl)).toEqual(expected);
+});
+
+test('parse Git URL from MBS', () => {
+    const scmUrl =
+        'git://pkgs.devel.redhat.com/modules/postgresql?#5e4b83c1a1aee5aebf585f140b538b1c07db84';
+    const expected: ScmUrlComponents = {
+        commit: '5e4b83c1a1aee5aebf585f140b538b1c07db84',
+        name: 'postgresql',
+        namespace: 'modules',
+    };
+    expect(parseScmUrl(scmUrl)).toEqual(expected);
+});
+
+test('fail to parse Git URL with no commit', () => {
+    const scmUrl = 'git://pkgs.devel.redhat.com/rpms/bash.git';
+    expect(parseScmUrl(scmUrl)).toBeUndefined();
+});
+
+test('fail to parse non-Git URL', () => {
+    const scmUrl = 'https://git.example.com/unexpected.git#4053763aa726f25e';
+    expect(parseScmUrl(scmUrl)).toBeUndefined();
 });

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -38,11 +38,13 @@ import { MSG_V_1, MSG_V_0_1, BrokerMessagesType } from '../types';
 import {
     Artifact,
     ArtifactType,
+    DistGitInstanceType,
     GreenwaveRequirementTypesType,
     isArtifactMBS,
     isArtifactRPM,
     KaiStateType,
     KojiInstanceType,
+    MbsInstanceType,
     StateExtendedKaiNameType,
     StateGreenwaveKaiType,
     StateGreenwaveType,
@@ -552,6 +554,45 @@ export const mkLinkPkgsDevelFromSource = (
             return `https://pkgs.devel.redhat.com/cgit/${namespace}/${name}/commit/?id=${commit}`;
         default:
             console.warn(`Unknown Koji instance: ${instance}`);
+            return '';
+    }
+};
+
+export const mkLinkFileInGit = (
+    repoName: string,
+    namespace: 'rpms' | 'modules',
+    commit: string,
+    fileName: string,
+    instance: DistGitInstanceType,
+) => {
+    switch (instance) {
+        case 'cs':
+            return `https://gitlab.com/redhat/centos-stream/${namespace}/${repoName}/-/blob/${commit}/${fileName}`;
+        case 'fp':
+            return `https://src.fedoraproject.org/${namespace}/${repoName}/blob/${commit}/f/${fileName}`;
+        case 'rh':
+            return `https://pkgs.devel.redhat.com/cgit/${namespace}/${repoName}/tree/${fileName}?h=${commit}`;
+        default:
+            console.warn(`Unknown Dist-Git instance: ${instance}`);
+            return '';
+    }
+};
+
+export const mkLinkMbsBuild = (
+    buildId: number | string,
+    instance: MbsInstanceType,
+) => {
+    switch (instance) {
+        case 'fp':
+            // TODO: Substitute the MBS frontend instance for Fedora.
+            return `https://koji.fedoraproject.org/koji/buildinfo?buildID=${buildId}`;
+        case 'cs':
+            // TODO: Substitute the MBS frontend instance for CentOS.
+            return `https://kojihub.stream.centos.org/koji/buildinfo?buildID=${buildId}`;
+        case 'rh':
+            return `https://mbsweb.engineering.redhat.com/module/${buildId}`;
+        default:
+            console.warn(`Unknown MBS instance: ${instance}`);
             return '';
     }
 };


### PR DESCRIPTION
Extend the build info component for artifacts to display information on module builds.

Reference: OSCI-3467
Related: fedora-ci/ciboard-server#4