### PR TITLE
Add GraphQL query info to #help page

### DIFF
--- a/src/components/PageHelp.tsx
+++ b/src/components/PageHelp.tsx
@@ -196,6 +196,12 @@ const Help = () => (
             {window.location.origin}
             /graphql
         </p>
+        <h4> Disclaimers</h4>
+        <p>
+            Note: the API is not officially supported and its primary use is 
+            for the CI Dashboard front-end. It is not guaranteed to be stable and 
+            it can change arbitrarily without prior notice.
+        </p>
         <h4>Examples</h4>
         <p>
             To retrieve build tags by NVR, your query could look something like this:

--- a/src/components/PageHelp.tsx
+++ b/src/components/PageHelp.tsx
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import * as React from 'react';
-import { TextContent, Text } from '@patternfly/react-core';
+import { TextContent, Text, CodeBlockCode } from '@patternfly/react-core';
 
 import { config } from '../config';
 import { PageCommon } from './PageCommon';
@@ -187,6 +187,32 @@ const Help = () => (
                 </tr>
             </tbody>
         </table>
+        <h3>Via GraphQL</h3>
+        <p>
+            You can construct GraphQL queries and execute them on the dashboard's 
+            backend GraphQL server. The GraphQL backend is usually located at:
+        </p>
+        <p className="padding-left-20">
+            {window.location.origin}
+            /graphql
+        </p>
+        <h4>Examples</h4>
+        <p>
+            To retrieve build tags by NVR, your query could look something like this:
+        </p>
+        <p className="padding-left-20">
+            <CodeBlockCode id="code-content">
+                {`query brew {
+                    koji_build_tags_by_nvr(nvr: $NVR, instance: rh|fp|cs){
+                        arches
+                        id
+                        locked
+                        name
+                        perm
+                        perm_id}
+                }`}
+            </CodeBlockCode>
+        </p>
         <h2>Onboarding</h2>
         <p>
             To onboard your system to the dashboard, just start sending out


### PR DESCRIPTION
Howdy,

Proposing to add basic GraphQL information under the help page as an additional resource under the "search" category.

Currently, there is no "straightforward" way for a user to deduce that the current dashboard instance has an API 'endpoint" from the help page. Pointing them in the right direction by explicitly mentioning the GraphQL background (and the appended link) would be of great help.

Proposing this as I got caught in a wild goose chase trying to figure out where "an API" was. Sorry if this seems trivial.

Thanks in advance.