### PR TITLE
Update GitHub Action versions

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -33,7 +33,7 @@ jobs:
         username: ${{ env.USER_QUAY }}
         password: ${{ secrets.PASSWORD_QUAY }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set outputs
       id: vars

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
         node-version: [14.x]
     steps:
       - name: Check out sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
The `checkout` and `setup-node` actions should be upgraded to their latest version. See the GitHub blog [1] for details.

[1]: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/