### PR TITLE
Dependabot - keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - 'type: dependencies'
+      - 'github-actions'
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - 'type: dependencies'
+      - 'npm'
+
+...


### PR DESCRIPTION
Adding Dependabot or a similar service could help manage the dependencies of `ciboard`. Currently, there are quite a few of outdated packages with security vulnerabilities:

![Screenshot from 2022-11-18 08-21-38](https://user-images.githubusercontent.com/2879818/202644604-b3b909b6-bc8f-4b9c-b139-ac18512e92b9.png)

Also, enabling Dependabot Security Alerts could help you to identify vulnerable packages sooner.

Related to:
- #6 
- #47 