### PR TITLE
Disallow explicit type declarations for variables or parameters initialized to a `number` / `string` / `boolean`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
     "@typescript-eslint/no-unused-vars": ["warn", {
       "args": "none",
       "varsIgnorePattern": "^_"
-    }]
-  }
+    }],
+    "@typescript-eslint/no-inferrable-types": "error"
+  },
+
+  "ignorePatterns": ["node_modules", "build", "coverage"]
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "eslint": "eslint .",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/actions/index.tsx
+++ b/src/actions/index.tsx
@@ -85,7 +85,7 @@ type AlertVariantType = 'success' | 'danger' | 'warning' | 'info' | 'default';
 export const pushAlert = (
     variant: AlertVariantType,
     title: React.ReactNode,
-    autoRm: boolean = true,
+    autoRm = true,
 ) => {
     return async (dispatch: DispatchType) => {
         const key = new Date().getTime();

--- a/src/components/ArtifactsListByFilters.tsx
+++ b/src/components/ArtifactsListByFilters.tsx
@@ -74,7 +74,7 @@ const ArtifactsTable: React.FC = () => {
     /** XXX */
     let artifacts: any[] = [];
     let hasNext = false;
-    let currentPage: number = 1;
+    let currentPage = 1;
     let loadNextIsDisabled = true;
     let loadPrevIsDisabled = true;
     useEffect(() => {

--- a/src/components/PageByMongoField.tsx
+++ b/src/components/PageByMongoField.tsx
@@ -95,7 +95,7 @@ const ArtifactsTable: React.FC<ArtifactsTableProps> = (props) => {
     // has_next -- returned by query from backend
     let hasNext = false;
     // currentPage -- index in known pages
-    let currentPage: number = 1;
+    let currentPage = 1;
     let loadNextIsDisabled = true;
     let loadPrevIsDisabled = true;
     // Index of the currently expanded artifact row within the `artifacts` list.


### PR DESCRIPTION
It is a good practice to allow `tsc` to infer the type from the assigned value. Eslint can help with enforcing this practice.