### PR TITLE
Create separate components for status icons

### DIFF
--- a/src/components/ArtifactGreenwaveKaiState.tsx
+++ b/src/components/ArtifactGreenwaveKaiState.tsx
@@ -59,7 +59,7 @@ import { Artifact, StateGreenwaveKaiType } from '../artifact';
 import {
     getUmbDocsUrl,
     isResultWaivable,
-    renderStatusIcon,
+    TestStatusIcon,
 } from '../utils/artifactUtils';
 import { ArtifactStateProps, StateLink } from './ArtifactState';
 import {
@@ -161,7 +161,9 @@ export const FaceForGreenwaveKaiState: React.FC<
     return (
         <Flex>
             <Flex flex={{ default: 'flex_1' }}>
-                <FlexItem>{renderStatusIcon(iconName)}</FlexItem>
+                <FlexItem>
+                    <TestStatusIcon status={iconName} />
+                </FlexItem>
                 <TextContent>
                     <Text className="pf-u-text-nowrap">
                         {state.gs.testcase}

--- a/src/components/ArtifactGreenwaveState.tsx
+++ b/src/components/ArtifactGreenwaveState.tsx
@@ -53,7 +53,6 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
-
 import {
     ExclamationCircleIcon,
     ExclamationTriangleIcon,
@@ -70,11 +69,11 @@ import styles from '../custom.module.css';
 import {
     LinkifyNewTab,
     isResultWaivable,
-    renderStatusIcon,
     timestampForUser,
     getGreenwaveDocsUrl,
     getTestcaseName,
     getArtifactProduct,
+    TestStatusIcon,
 } from '../utils/artifactUtils';
 import {
     Artifact,
@@ -237,7 +236,7 @@ export const GreenwaveDetails: React.FC<GreenwaveDetailsProps> = ({
 }) => {
     if (!requirement || !requirement.details) return null;
 
-    const icon = renderStatusIcon(requirement.type);
+    const icon = <TestStatusIcon status={requirement.type} />;
     let title = 'Result details';
     let variant: AlertProps['variant'] = 'default';
 
@@ -362,7 +361,9 @@ export const FaceForGreenwaveState: React.FC<FaceForGreenwaveStateProps> = (
     return (
         <Flex>
             <Flex flex={{ default: 'flex_1' }}>
-                <FlexItem>{renderStatusIcon(iconName)}</FlexItem>
+                <FlexItem>
+                    <TestStatusIcon status={iconName} />
+                </FlexItem>
                 <TextContent>
                     <Text className="pf-u-text-nowrap">{state.testcase}</Text>
                 </TextContent>

--- a/src/components/ArtifactKaiState.tsx
+++ b/src/components/ArtifactKaiState.tsx
@@ -65,7 +65,7 @@ import {
     getThreadID,
     getUmbDocsUrl,
     LinkifyNewTab,
-    renderStatusIcon,
+    TestStatusIcon,
 } from '../utils/artifactUtils';
 import { MSG_V_1, MSG_V_0_1, Metadata } from '../types';
 import { Artifact, StateKaiType, StateNameType } from '../artifact';
@@ -363,7 +363,9 @@ const FaceForKaiState: React.FC<FaceForKaiStateProps> = (props) => {
     return (
         <Flex>
             <Flex flex={{ default: 'flex_1' }}>
-                <Flex>{renderStatusIcon(result)}</Flex>
+                <Flex>
+                    <TestStatusIcon status={result} />
+                </Flex>
                 <Flex flexWrap={{ default: 'nowrap' }}>
                     <StageName state={state} />
                 </Flex>

--- a/src/components/GatingStatus.tsx
+++ b/src/components/GatingStatus.tsx
@@ -29,14 +29,18 @@ import {
     Spinner,
 } from '@patternfly/react-core';
 
-import { isGatingArtifact, resultColor } from '../utils/artifactUtils';
-import { renderStatusIcon } from '../utils/artifactUtils';
+import {
+    GatingStatusIcon,
+    isGatingArtifact,
+    resultColor,
+} from '../utils/artifactUtils';
 import { Artifact, GreenwaveDecisionReplyType } from '../artifact';
 
 interface PrintRequirementsSizeProps {
     allReqs: { [key: string]: number };
     reqName: string;
 }
+
 const PrintRequirementsSize = (props: PrintRequirementsSizeProps) => {
     const { reqName, allReqs } = props;
     const color = resultColor(reqName);
@@ -57,6 +61,7 @@ interface ArtifactGreenwaveStatesSummaryProps {
     artifact: Artifact;
     isLoading: boolean;
 }
+
 export const ArtifactGreenwaveStatesSummary: React.FC<
     ArtifactGreenwaveStatesSummaryProps
 > = (props) => {
@@ -73,6 +78,7 @@ export const ArtifactGreenwaveStatesSummary: React.FC<
     if (_.isNil(decision) && !isLoading) {
         return null;
     }
+
     const reqSummary: { [name: string]: number } = {};
     /*
      * Ignore the 'fetched-gating-yaml' virtual test as we dont display it in the UI.
@@ -89,16 +95,18 @@ export const ArtifactGreenwaveStatesSummary: React.FC<
     if (unsatisfiedCount) {
         reqSummary['unsatisfied'] = unsatisfiedCount;
     }
-    const iconColor = isLoading
-        ? 'info'
-        : _.toString(decision?.policies_satisfied);
+
+    const gatingPassed = decision?.policies_satisfied;
+    const iconStyle = { height: '1.2em' };
+    const statusIcon = isLoading ? null : (
+        <GatingStatusIcon status={gatingPassed} style={iconStyle} />
+    );
+
     return (
         <Flex flexWrap={{ default: 'nowrap' }}>
-            <FlexItem key="3">
+            <FlexItem>
                 <TextContent>
-                    <Text>
-                        {renderStatusIcon(iconColor, 'gating', '1.2em')}
-                    </Text>
+                    <Text>{statusIcon}</Text>
                 </TextContent>
             </FlexItem>
             {_.map(reqSummary, (_len, reqName) => (
@@ -110,7 +118,7 @@ export const ArtifactGreenwaveStatesSummary: React.FC<
                 </FlexItem>
             ))}
             {isLoading && (
-                <FlexItem key="spiner" spacer={{ default: 'spacerMd' }}>
+                <FlexItem spacer={{ default: 'spacerMd' }}>
                     <Spinner size="sm" />
                 </FlexItem>
             )}

--- a/src/components/TestSuites.tsx
+++ b/src/components/TestSuites.tsx
@@ -54,7 +54,7 @@ import { MicrochipIcon, OutlinedClockIcon } from '@patternfly/react-icons';
 import classNames from 'classnames';
 
 import { Artifact, StateKaiType } from '../artifact';
-import { mapTypeToIconsProps, renderStatusIcon } from '../utils/artifactUtils';
+import { mapTypeToIconsProps, TestStatusIcon } from '../utils/artifactUtils';
 import { ArtifactsXunitQuery } from '../queries/Artifacts';
 import { mkSeparatedList } from '../utils/artifactsTable';
 import { xunitParser } from '../utils/xunitParser';
@@ -128,7 +128,7 @@ const mkLogsLinks = (logs: TestCaseLogs[]): JSX.Element[] => {
 const mkPhase = (phase: TestCasePhasesEntry): IRow => {
     return {
         cells: [
-            renderStatusIcon(phase.$.result),
+            <TestStatusIcon status={phase.$.result} />,
             phase.$.name,
             mkSeparatedList(mkLogsLinks(phase.logs)),
         ],
@@ -268,7 +268,9 @@ const TestCaseItem: React.FC<TestCaseItemProps> = (props) => {
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
                 <Flex>
-                    <FlexItem>{renderStatusIcon(test.status)}</FlexItem>
+                    <FlexItem>
+                        <TestStatusIcon status={test.status} />
+                    </FlexItem>
                     <FlexItem className={nameClassName}>{test.name}</FlexItem>
                     <FlexItem>
                         <ArchitectureLabel architecture={machineArchitecture} />
@@ -374,26 +376,32 @@ const TestSuiteDisplay: React.FC<TestSuiteDisplayProps> = (props) => {
     return (
         <>
             <Flex>
-                {_.map(toggleState, (isChecked, outcome: TestSuiteStatus) => {
-                    if (_.isNil(isChecked)) return <></>;
-                    const label = (
-                        <>
-                            {renderStatusIcon(outcome)} {suite.count[outcome]}
-                        </>
-                    );
-                    return (
-                        <FlexItem key={outcome}>
-                            <Checkbox
-                                aria-label={`Toggle display of results in status ${outcome}`}
-                                id={`check-${outcome}-${suite._uuid}`}
-                                isChecked={isChecked}
-                                label={label}
-                                name={outcome}
-                                onChange={() => onToggle(outcome, isChecked)}
-                            />
-                        </FlexItem>
-                    );
-                })}
+                {_.map(
+                    toggleState,
+                    (isChecked: boolean, outcome: TestSuiteStatus) => {
+                        if (_.isNil(isChecked)) return <></>;
+                        const label = (
+                            <>
+                                <TestStatusIcon status={outcome} />{' '}
+                                {suite.count[outcome]}
+                            </>
+                        );
+                        return (
+                            <FlexItem key={outcome}>
+                                <Checkbox
+                                    aria-label={`Toggle display of results in status ${outcome}`}
+                                    id={`check-${outcome}-${suite._uuid}`}
+                                    isChecked={isChecked}
+                                    label={label}
+                                    name={outcome}
+                                    onChange={() =>
+                                        onToggle(outcome, isChecked)
+                                    }
+                                />
+                            </FlexItem>
+                        );
+                    },
+                )}
             </Flex>
 
             <DataList aria-label="Test suite items" isCompact>

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -55,6 +55,7 @@ import {
 } from '../artifact';
 import { config } from '../config';
 import { MSG_V_1, MSG_V_0_1, BrokerMessagesType } from '../types';
+import { CSSProperties } from 'react';
 
 /**
  *Typescript guards
@@ -285,8 +286,6 @@ export const resultColor = (result: string) => {
     return _.findKey(resultColors, (item) => item.indexOf(result) !== -1);
 };
 
-type modifyType = 'gating' | 'test';
-
 export const getThreadID = (args: {
     kai_state?: KaiStateType;
     broker_msg_body?: BrokerMessagesType;
@@ -482,36 +481,66 @@ export const isGatingArtifact = (artifact: Artifact): boolean => {
     return false;
 };
 
-export const renderStatusIcon = (
-    type: string,
-    mod: modifyType = 'test',
-    size = '1em',
-) => {
-    const typeLC = _.toLower(type);
-    const iconProps = mapTypeToIconsProps(typeLC);
+export interface TestStatusIconProps {
+    /**
+     * String indicating the status/outcome of the test.
+     * Examples: 'pass', 'failed', 'error', 'info'.
+     */
+    status: string;
+    /** Additional styling for the icon. */
+    style?: CSSProperties;
+}
+
+export function TestStatusIcon(props: TestStatusIconProps) {
+    const statusLower = props.status.toLowerCase();
+    const iconProps = mapTypeToIconsProps(statusLower);
+
     if (!iconProps) {
-        console.warn('Asked to render icon with unknown type:', type);
+        console.warn('Asked to render icon with unknown status:', props.status);
         return (
             <OutlinedQuestionCircleIcon aria-label="Result is unknown type." />
         );
     }
+
     let Icon = iconProps.icon;
-    if (mod === 'gating') {
-        Icon = TrafficLightIcon;
-    }
-    const style = {
-        height: size,
-    };
+
     return (
         <Icon
             aria-label={iconProps.label}
             className={iconProps.className}
             size="sm"
-            style={style}
+            style={props.style}
             title={iconProps.label}
         />
     );
-};
+}
+
+export interface GatingStatusIconProps {
+    /** Boolean indicating whether gating has passed. The default is false. */
+    status?: boolean;
+    /** Additional styling for the icon. */
+    style?: CSSProperties;
+}
+
+export function GatingStatusIcon(props: GatingStatusIconProps) {
+    let className = 'pf-u-danger-color-100';
+    let label = 'Gating is blocked';
+
+    if (props.status) {
+        className = 'pf-u-success-color-100';
+        label = 'Gating has passed';
+    }
+
+    return (
+        <TrafficLightIcon
+            aria-label={label}
+            className={className}
+            size="sm"
+            style={props.style}
+            title={label}
+        />
+    );
+}
 
 const SCM_COMMIT_URL_REGEX =
     /\/(rpms|modules)\/([\w-]+)(?:\.git)?\/?\??#([0-9a-fA-F]+)$/;


### PR DESCRIPTION
Replace the `renderStatusIcon` function with two separate icon components, `TestStatusIcon` for test statuses (passed, failed, running, missing, etc.) and `GatingStatusIcon` for gating status (red or green semaphore).

This is a small piece of refactoring that came out of my work on the redesign, but it's independent so I'm proposing it directly for main.