### PR TITLE
Add empty state for related advisories

### DIFF
--- a/src/components/ArtifactDetailedInfo.tsx
+++ b/src/components/ArtifactDetailedInfo.tsx
@@ -336,7 +336,16 @@ interface LinkedAdvisoriesProps {
 const LinkedAdvisories: React.FC<LinkedAdvisoriesProps> = (props) => {
     const { linkedAdvisories } = props;
     if (_.isNil(linkedAdvisories)) {
-        return null;
+        return (
+            <Flex className="pf-u-p-lg">
+                <Alert
+                    isInline
+                    isPlain
+                    title="No advisories linked to this artifact"
+                    variant="info"
+                />
+            </Flex>
+        );
     }
     const advs: JSX.Element[] = [];
     for (const adv of linkedAdvisories) {


### PR DESCRIPTION
Show an info alert in the "Related Advisories" tab if there are no errata linked to the build. This makes the distinction between an empty and broken or loading state much clearer.