### PR TITLE
Results page redesign, checkpoint 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "TZ=Europe/Prague react-scripts test",
     "eslint": "eslint .",
     "eject": "react-scripts eject"
   },

--- a/src/components/ArtifactDetailedInfo.tsx
+++ b/src/components/ArtifactDetailedInfo.tsx
@@ -43,6 +43,14 @@ import {
     HelperTextItem,
     HelperTextItemProps,
 } from '@patternfly/react-core';
+import {
+    TableComposable,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
 import classNames from 'classnames';
 
 import { config, mappingDatagrepperUrl } from '../config';
@@ -81,15 +89,8 @@ import {
     mkLinkMbsBuild,
     mkLinkPkgsDevelFromSource,
 } from '../utils/artifactUtils';
+import { secondsToTimestampWithTz } from '../utils/timeUtils';
 import { ExternalLink } from './ExternalLink';
-import {
-    Tr,
-    Td,
-    Th,
-    Tbody,
-    Thead,
-    TableComposable,
-} from '@patternfly/react-table';
 
 interface NoDataProps {
     show: boolean;
@@ -180,7 +181,7 @@ const BuildInfo: React.FC<BuildInfoProps> = (props) => {
                 <DescriptionListTerm>Git commit</DescriptionListTerm>
                 <DescriptionListDescription>
                     <a
-                        className={styles['buildInfoCommitHash']}
+                        className={styles['commitHash']}
                         href={mkLinkPkgsDevelFromSource(build.source, instance)}
                         target="_blank"
                         rel="noopener noreferrer"
@@ -212,17 +213,13 @@ const BuildInfo: React.FC<BuildInfoProps> = (props) => {
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>Build completed</DescriptionListTerm>
-                <DescriptionListDescription
-                    className={styles['buildInfoTimestamp']}
-                >
+                <DescriptionListDescription className={styles['timestamp']}>
                     {buildTimeWithTz}
                 </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>Commit time</DescriptionListTerm>
-                <DescriptionListDescription
-                    className={styles['buildInfoTimestamp']}
-                >
+                <DescriptionListDescription className={styles['timestamp']}>
                     {commitTimeWithTz}
                 </DescriptionListDescription>
             </DescriptionListGroup>
@@ -230,29 +227,30 @@ const BuildInfo: React.FC<BuildInfoProps> = (props) => {
     );
 };
 
-interface TagsListProps {
+export interface TagsListProps {
     build?: KojiBuildInfo;
     instance: KojiInstanceType;
 }
-const TagsList: React.FC<TagsListProps> = (props) => {
+
+export const TagsList: React.FC<TagsListProps> = (props) => {
     const { build, instance } = props;
     if (_.isNil(build)) {
         return null;
     }
     return (
-        <Flex className="pf-u-p-md" flex={{ default: 'flexNone' }}>
-            <List component={ListComponent.ol} type={OrderType.number}>
-                {_.map(build.tags, (tag) => (
-                    <ListItem key={tag.id}>
-                        <ExternalLink
-                            href={mkLinkKojiWebTagId(tag.id, instance)}
-                        >
-                            {tag.name}
-                        </ExternalLink>
-                    </ListItem>
-                ))}
-            </List>
-        </Flex>
+        <List
+            className="pf-u-font-size-sm"
+            component={ListComponent.ol}
+            type={OrderType.number}
+        >
+            {_.map(build.tags, (tag) => (
+                <ListItem key={tag.id}>
+                    <ExternalLink href={mkLinkKojiWebTagId(tag.id, instance)}>
+                        {tag.name}
+                    </ExternalLink>
+                </ListItem>
+            ))}
+        </List>
     );
 };
 
@@ -585,7 +583,7 @@ const ArtifactDetailedInfoModuleBuild: React.FC<
 
     const gitCommitLink = build.scmurl && (
         <ExternalLink
-            className={styles['buildInfoCommitHash']}
+            className={styles['commitHash']}
             href={mkLinkPkgsDevelFromSource(build.scmurl, instance)}
         >
             {mkCommitHashFromSource(build.scmurl)}
@@ -674,7 +672,7 @@ const ArtifactDetailedInfoModuleBuild: React.FC<
                             Build completed
                         </DescriptionListTerm>
                         <DescriptionListDescription
-                            className={styles['buildInfoTimestamp']}
+                            className={styles['timestamp']}
                         >
                             {buildTimeWithTz}
                         </DescriptionListDescription>
@@ -682,7 +680,7 @@ const ArtifactDetailedInfoModuleBuild: React.FC<
                     <DescriptionListGroup>
                         <DescriptionListTerm>Commit time</DescriptionListTerm>
                         <DescriptionListDescription
-                            className={styles['buildInfoTimestamp']}
+                            className={styles['timestamp']}
                         >
                             {commitTimeWithTz}
                         </DescriptionListDescription>
@@ -761,11 +759,11 @@ interface TagActionHistoryType {
     time: number;
 }
 
-interface HistoryListProps {
+export interface HistoryListProps {
     history?: KojiBuildTagging[];
 }
 
-const HistoryList: React.FC<HistoryListProps> = (props) => {
+export const HistoryList: React.FC<HistoryListProps> = (props) => {
     const { history } = props;
     if (_.isNil(history)) return null;
     const lines: TagActionHistoryType[] = [];
@@ -791,7 +789,11 @@ const HistoryList: React.FC<HistoryListProps> = (props) => {
     });
     const log = _.orderBy(lines, ['time'], ['asc']);
     return (
-        <List component={ListComponent.ol} type={OrderType.number}>
+        <List
+            className="pf-u-font-size-sm"
+            component={ListComponent.ol}
+            type={OrderType.number}
+        >
             {_.map(log, (entry) => {
                 return (
                     <ListItem key={entry.action + entry.time}>
@@ -808,13 +810,12 @@ export const LimitWithScroll = (
 ) => {
     const { children } = props;
     return (
-        <Flex className="pf-u-p-md" flex={{ default: 'flexNone' }}>
+        <Flex className="pf-u-p-md">
             <FlexItem
                 flex={{ default: 'flex_1' }}
                 style={{
                     maxHeight: '10em',
                     overflow: 'auto',
-                    flex: 'initial',
                 }}
             >
                 {children}
@@ -831,14 +832,12 @@ const HistoryListEntry: React.FC<HistoryListEntryProps> = (props) => {
     const {
         entry: { action, active, person_name, tag_name, time },
     } = props;
-    const eventTimeLocal = moment.unix(time).local();
-    const eventTimeWithTz = eventTimeLocal.format('YYYY-MM-DD, HH:mm');
-    const shift = eventTimeLocal.format('ZZ');
+    const eventTimeWithTz = secondsToTimestampWithTz(time);
     const flag = active ? '[still active]' : '';
     return (
         <div style={{ whiteSpace: 'nowrap' }}>
-            {eventTimeWithTz} {shift} {action} {tag_name} by {person_name}{' '}
-            {flag}
+            <span className={styles['timestamp']}>{eventTimeWithTz}</span>{' '}
+            {action} {tag_name} by {person_name} {flag}
         </div>
     );
 };

--- a/src/components/ArtifactDetailedInfo.tsx
+++ b/src/components/ArtifactDetailedInfo.tsx
@@ -112,10 +112,11 @@ const NoData: React.FC<NoDataProps> = (props) => {
     );
 };
 
-interface LoadingDataProps {
+export interface LoadingDataProps {
     show: boolean;
 }
-const LoadingData: React.FC<LoadingDataProps> = (props) => {
+
+export const LoadingData: React.FC<LoadingDataProps> = (props) => {
     const { show } = props;
     if (!show) {
         return null;
@@ -342,21 +343,20 @@ const ArtifactDetailedInfoKojiBuild: React.FC<
     );
 };
 
-interface LinkedAdvisoriesProps {
-    linkedAdvisories: ErrataLinkedAdvisory[] | undefined;
+export interface LinkedAdvisoriesProps {
+    linkedAdvisories?: ErrataLinkedAdvisory[];
 }
-const LinkedAdvisories: React.FC<LinkedAdvisoriesProps> = (props) => {
+
+export const LinkedAdvisories: React.FC<LinkedAdvisoriesProps> = (props) => {
     const { linkedAdvisories } = props;
     if (_.isNil(linkedAdvisories)) {
         return (
-            <Flex className="pf-u-p-lg">
-                <Alert
-                    isInline
-                    isPlain
-                    title="No advisories linked to this artifact"
-                    variant="info"
-                />
-            </Flex>
+            <Alert
+                isInline
+                isPlain
+                title="No advisories linked to this artifact"
+                variant="info"
+            />
         );
     }
     const advs: JSX.Element[] = [];

--- a/src/components/PageResultsNew/BuildInfo.tsx
+++ b/src/components/PageResultsNew/BuildInfo.tsx
@@ -118,7 +118,7 @@ export function BuildInfo(_props: {}) {
 
     // TODO: Replace with real data.
     const buildProps = {
-        buildId: 4115943,
+        buildId: 2181999,
         buildTime: '2022-09-16 10:27 +02:00',
         commit: '81bf54a75572bddc61e6b0b250b4fb45c5aa9856',
         commitTime: '2022-09-16 09:12 +02:00',

--- a/src/components/PageResultsNew/BuildInfo.tsx
+++ b/src/components/PageResultsNew/BuildInfo.tsx
@@ -123,7 +123,7 @@ export function BuildInfo(_props: {}) {
         commit: '81bf54a75572bddc61e6b0b250b4fb45c5aa9856',
         commitTime: '2022-09-16 09:12 +02:00',
         committerEmail: 'mgrabovs@redhat.com',
-        committerName: 'mgrabovs',
+        committerName: 'Matěj Grabovský',
         owner: 'mgrabovs',
     };
 

--- a/src/components/PageResultsNew/DetailsDrawer.tsx
+++ b/src/components/PageResultsNew/DetailsDrawer.tsx
@@ -47,11 +47,11 @@ import {
     ExclamationCircleIcon,
     HandPaperIcon,
     InfoCircleIcon,
-    SyncAltIcon,
+    RedoIcon,
     ThumbsUpIcon,
 } from '@patternfly/react-icons';
 
-import { LinkifyNewTab } from '../../utils/artifactUtils';
+import { LinkifyNewTab, TestStatusIcon } from '../../utils/artifactUtils';
 import { ExternalLink } from '../ExternalLink';
 import { SelectedTestContext } from './contexts';
 import { FAKE_TEST_SUITES } from './fakeData';
@@ -197,6 +197,9 @@ export function DetailsDrawer(props: DetailsDrawerProps) {
 
     const onCloseClick = () => props.onClose && props.onClose();
     const onResize = (newWidth: number) => setDrawerSize(`${newWidth}px`);
+    const statusIcon = selectedTest ? (
+        <TestStatusIcon status={selectedTest.status} />
+    ) : null;
 
     // TODO: Persist the drawer width across pages/sessions.
     const panelContent = (
@@ -208,7 +211,7 @@ export function DetailsDrawer(props: DetailsDrawerProps) {
         >
             <DrawerHead>
                 <Title className="pf-u-pb-sm" headingLevel="h3" size="xl">
-                    {selectedTest?.name}
+                    {statusIcon} {selectedTest?.name}
                 </Title>
                 <DrawerActions>
                     <DrawerCloseButton onClick={onCloseClick} />
@@ -229,7 +232,7 @@ export function DetailsDrawer(props: DetailsDrawerProps) {
                     )}
                     <Button
                         className="pf-u-p-0"
-                        icon={<SyncAltIcon />}
+                        icon={<RedoIcon />}
                         variant="link"
                     >
                         Rerun

--- a/src/components/PageResultsNew/DetailsDrawer.tsx
+++ b/src/components/PageResultsNew/DetailsDrawer.tsx
@@ -198,7 +198,10 @@ export function DetailsDrawer(props: DetailsDrawerProps) {
     const onCloseClick = () => props.onClose && props.onClose();
     const onResize = (newWidth: number) => setDrawerSize(`${newWidth}px`);
     const statusIcon = selectedTest ? (
-        <TestStatusIcon status={selectedTest.status} />
+        <TestStatusIcon
+            status={selectedTest.status}
+            style={{ verticalAlign: '-.125em' }}
+        />
     ) : null;
 
     // TODO: Persist the drawer width across pages/sessions.

--- a/src/components/PageResultsNew/DetailsDrawer.tsx
+++ b/src/components/PageResultsNew/DetailsDrawer.tsx
@@ -204,7 +204,6 @@ export function DetailsDrawer(props: DetailsDrawerProps) {
         />
     ) : null;
 
-    // TODO: Persist the drawer width across pages/sessions.
     const panelContent = (
         <DrawerPanelContent
             defaultSize={drawerSize}
@@ -224,7 +223,7 @@ export function DetailsDrawer(props: DetailsDrawerProps) {
                         default: 'spaceItemsLg',
                     }}
                 >
-                    {selectedTest?.isWaivable && (
+                    {selectedTest?.waivable && (
                         <Button
                             className="pf-u-p-0"
                             icon={<ThumbsUpIcon />}

--- a/src/components/PageResultsNew/Header.tsx
+++ b/src/components/PageResultsNew/Header.tsx
@@ -27,7 +27,11 @@ import {
     TextContent,
     Title,
 } from '@patternfly/react-core';
-import { AngleLeftIcon, CubeIcon } from '@patternfly/react-icons';
+import {
+    AngleLeftIcon,
+    CodeBranchIcon,
+    CubeIcon,
+} from '@patternfly/react-icons';
 
 import { GatingStatusIcon } from '../../utils/artifactUtils';
 import { ExternalLink } from '../ExternalLink';
@@ -70,7 +74,7 @@ function ArtifactTitle(props: SummaryHeaderProps) {
             {props.isScratch && <span className="pf-u-color-200">scratch</span>}
             {!props.isScratch && props.gatingTag && (
                 <span className="pf-u-color-200" title="Gating tag">
-                    {props.gatingTag}
+                    <CodeBranchIcon /> {props.gatingTag}
                 </span>
             )}
         </Flex>

--- a/src/components/PageResultsNew/Header.tsx
+++ b/src/components/PageResultsNew/Header.tsx
@@ -22,14 +22,17 @@ import {
     Button,
     Flex,
     FlexItem,
+    Stack,
+    StackItem,
     TextContent,
     Title,
 } from '@patternfly/react-core';
-import { AngleLeftIcon } from '@patternfly/react-icons';
+import { AngleLeftIcon, CubeIcon } from '@patternfly/react-icons';
 
 import { GatingStatusIcon } from '../../utils/artifactUtils';
+import { ExternalLink } from '../ExternalLink';
 
-export function BackButton(_props: {}) {
+function BackButton(_props: {}) {
     return (
         <Button className="pf-u-px-0" icon={<AngleLeftIcon />} variant="link">
             Back to results list
@@ -37,7 +40,7 @@ export function BackButton(_props: {}) {
     );
 }
 
-export interface SummaryHeaderProps {
+interface SummaryHeaderProps {
     gatingStatus?: 'fail' | 'pass';
     gatingTag?: string;
     isScratch?: boolean;
@@ -45,8 +48,7 @@ export interface SummaryHeaderProps {
     owner: string;
 }
 
-// TODO: Better naming.
-export function SummaryHeader(props: SummaryHeaderProps) {
+function ArtifactTitle(props: SummaryHeaderProps) {
     return (
         <Flex spaceItems={{ default: 'spaceItemsLg' }}>
             <TextContent>
@@ -72,5 +74,44 @@ export function SummaryHeader(props: SummaryHeaderProps) {
                 </span>
             )}
         </Flex>
+    );
+}
+
+interface PageHeaderProps {
+    gatingStatus?: 'fail' | 'pass';
+    gatingTag?: string;
+    hasBackLink?: boolean;
+    isScratch?: boolean;
+    nvr: string;
+    owner: string;
+    taskId: number;
+}
+
+export function ArtifactHeader(props: PageHeaderProps) {
+    const taskLabel = `Brew #${props.taskId}`;
+
+    return (
+        <Stack className="resultsNarrower">
+            {props.hasBackLink && (
+                <StackItem>
+                    <BackButton />
+                </StackItem>
+            )}
+            <StackItem>
+                <ExternalLink href="#">
+                    <CubeIcon style={{ verticalAlign: '-.125em' }} />{' '}
+                    {taskLabel}
+                </ExternalLink>
+            </StackItem>
+            <StackItem>
+                {/* TODO: Display real data. */}
+                <ArtifactTitle
+                    gatingStatus="fail"
+                    gatingTag={props.gatingTag}
+                    nvr={props.nvr}
+                    owner={props.owner}
+                />
+            </StackItem>
+        </Stack>
     );
 }

--- a/src/components/PageResultsNew/TestResultsTable.tsx
+++ b/src/components/PageResultsNew/TestResultsTable.tsx
@@ -18,8 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import * as _ from 'lodash';
 import { ReactNode, useContext } from 'react';
-import { Button, Flex, Label, Title } from '@patternfly/react-core';
+import {
+    Alert,
+    Button,
+    CardBody,
+    Flex,
+    Label,
+    Title,
+} from '@patternfly/react-core';
 import {
     TableComposable,
     Tbody,
@@ -181,7 +189,18 @@ export function TestResultsTable(props: TestResultsTableProps) {
     const { tests } = props;
     const selectedTest = useContext(SelectedTestContext);
 
-    // TODO: Handle the empty case, i.e. when there are no (known) tests.
+    if (_.isEmpty(tests)) {
+        return (
+            <CardBody>
+                <Alert
+                    isInline
+                    isPlain
+                    title="No test results found for this artifact"
+                    variant="info"
+                />
+            </CardBody>
+        );
+    }
 
     const failedRequiredRows = tests
         .filter(
@@ -202,7 +221,7 @@ export function TestResultsTable(props: TestResultsTableProps) {
                 <Td>
                     <SingleTestRow
                         isRequired
-                        isWaivable={row.isWaivable}
+                        isWaivable={row.waivable}
                         isWaived={row.status === 'waived'}
                         labels={row.labels}
                         name={row.name}
@@ -235,7 +254,7 @@ export function TestResultsTable(props: TestResultsTableProps) {
                 <Td>
                     <SingleTestRow
                         isRequired
-                        isWaivable={row.isWaivable}
+                        isWaivable={row.waivable}
                         isWaived={row.status === 'waived'}
                         labels={row.labels}
                         name={row.name}
@@ -295,10 +314,19 @@ export function TestResultsTable(props: TestResultsTableProps) {
             </Tr>
         ));
 
+    /*
+     * TODO: Refactor the table for readability.
+     * TODO: Sorts tests within sections:
+     *      - in failed: alphabetically
+     *      - in awaited: missing first, then running, then alphabetically
+     *      - in passed: waived first, then alphabetically
+     *      - in additional: failed+errored+needs_inspection first,
+     *          then info/not_applicable, then
+     * TODO: Where to put waived tests in this order?
+     */
     return (
         <TableComposable variant="compact">
-            {/* TODO: Where to put waived tests in this order? */}
-            {failedRequiredRows.length && (
+            {failedRequiredRows.length > 0 && (
                 <>
                     <Thead>
                         <Tr>
@@ -311,7 +339,7 @@ export function TestResultsTable(props: TestResultsTableProps) {
                     <Tbody>{failedRequiredRows}</Tbody>
                 </>
             )}
-            {awaitedRequiredRows.length && (
+            {awaitedRequiredRows.length > 0 && (
                 <>
                     <Thead>
                         <Tr>
@@ -324,7 +352,7 @@ export function TestResultsTable(props: TestResultsTableProps) {
                     <Tbody>{awaitedRequiredRows}</Tbody>
                 </>
             )}
-            {passedRequiredRows.length && (
+            {passedRequiredRows.length > 0 && (
                 <>
                     <Thead>
                         <Tr>
@@ -337,7 +365,7 @@ export function TestResultsTable(props: TestResultsTableProps) {
                     <Tbody>{passedRequiredRows}</Tbody>
                 </>
             )}
-            {additionalRows.length && (
+            {additionalRows.length > 0 && (
                 <>
                     <Thead>
                         <Tr>

--- a/src/components/PageResultsNew/TestSuitesAccordion.tsx
+++ b/src/components/PageResultsNew/TestSuitesAccordion.tsx
@@ -37,6 +37,7 @@ import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table';
 import moment from 'moment';
 import update from 'immutability-helper';
 
+import './index.css';
 import { TestCase, TestSuite } from './types';
 import { mkSeparatedList } from '../../utils/artifactsTable';
 import { TestStatusIcon } from '../../utils/artifactUtils';
@@ -98,7 +99,7 @@ function TestCasesTable(props: TestCasesTableProps) {
         );
 
     return (
-        <TableComposable variant="compact">
+        <TableComposable className="testCasesTable" variant="compact">
             <Tbody>
                 {cases.map((testCase) => (
                     // TODO: Use a unique ID here later.

--- a/src/components/PageResultsNew/fakeData.ts
+++ b/src/components/PageResultsNew/fakeData.ts
@@ -26,28 +26,28 @@ import { CiTest, TestCase, TestSuite } from './types';
  */
 export const FAKE_TESTS: CiTest[] = [
     {
-        isWaivable: true,
         labels: ['rhel-linux_P9', 'ppc64le', 'python3-libvirt'],
         name: 'leapp.brew-build.upgrade.distro',
         required: true,
         status: 'failed',
         subtitle: 'Depends on osci.brew-build.test-compose.integration.',
+        waivable: true,
     },
     {
-        isWaivable: true,
         labels: ['ppc64le'],
         name: 'baseos-ci.brew-build.ci-dnf-stack-gating.functional',
         required: true,
         status: 'error',
         subtitle:
             'Test failed because of CI infrastructure. Please contact the CI system maintainers.',
+        waivable: true,
     },
     {
-        isWaivable: true,
         labels: ['x86_64'],
         name: 'redhat-cloud-client-configuration.brew-build.tier0.functional',
         required: true,
         status: 'missing',
+        waivable: true,
     },
     {
         name: 'osci.brew-build.virtual.always-running',

--- a/src/components/PageResultsNew/index.css
+++ b/src/components/PageResultsNew/index.css
@@ -46,3 +46,7 @@
     max-width: 80rem;
     margin: 0 auto;
 }
+
+.testCasesTable tr:last-child {
+    border-bottom: none;
+}

--- a/src/components/PageResultsNew/index.tsx
+++ b/src/components/PageResultsNew/index.tsx
@@ -26,6 +26,7 @@ import {
     PageSectionVariants,
 } from '@patternfly/react-core';
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { config } from '../../config';
 import { PageCommon } from '../PageCommon';
@@ -39,8 +40,13 @@ import { BuildInfo } from './BuildInfo';
 import { DetailsDrawer } from './DetailsDrawer';
 import { ArtifactHeader } from './Header';
 
+interface PageResultsNewParams {
+    task_id?: string;
+}
+
 export function PageResultsNew(_props: {}) {
     const [selectedTest, setSelectedTest] = useState<CiTest | undefined>();
+    const params = useParams<PageResultsNewParams>();
 
     const pageTitle = `🚧 New test results | ${config.defaultTitle}`;
 
@@ -48,7 +54,15 @@ export function PageResultsNew(_props: {}) {
     const buildNvr = 'ansible-collection-microsoft-sql-1.2.4-1.el9';
     const buildOwner = 'mgrabovs';
     const gatingTag = 'rhel-8.7.0-build-sidetag-101738-stack-gate';
-    const taskId = 47942709;
+    const taskId = params.task_id ? Number(params.task_id) : 47942709;
+
+    /*
+     * TODO: Load build info and test results if `taskId` is specified.
+     * - build info: ArtifactsDetailedInfoKojiTask for RPMs,
+     *               ArtifactsDetailedInfoModuleBuild for modules
+     * - list of artifacts: ArtifactsCompleteQuery
+     * For details, see `PageByMongoField`.
+     */
 
     // TODO: Use unique key later on.
     const onTestSelect = (name: string | undefined) => {

--- a/src/components/PageResultsNew/index.tsx
+++ b/src/components/PageResultsNew/index.tsx
@@ -30,6 +30,7 @@ import { useParams } from 'react-router-dom';
 
 import { config } from '../../config';
 import { PageCommon } from '../PageCommon';
+import { ArtifactRPM } from '../../artifact';
 
 import './index.css';
 import { CiTest } from './types';
@@ -55,6 +56,25 @@ export function PageResultsNew(_props: {}) {
     const buildOwner = 'mgrabovs';
     const gatingTag = 'rhel-8.7.0-build-sidetag-101738-stack-gate';
     const taskId = params.task_id ? Number(params.task_id) : 47942709;
+    const artifact: ArtifactRPM = {
+        _id: 'dummy',
+        _updated: 'dummy',
+        _version: 'dummy',
+        aid: taskId.toString(),
+        resultsdb_testscase: [],
+        states: [],
+        type: 'brew-build',
+        payload: {
+            build_id: 2181999,
+            component: 'ansible-collection-microsoft-sql',
+            gate_tag_name: gatingTag,
+            issuer: 'mgrabovs',
+            nvr: buildNvr,
+            source: 'https://example.com/git/0432ca7d',
+            scratch: false,
+            task_id: taskId,
+        },
+    };
 
     /*
      * TODO: Load build info and test results if `taskId` is specified.
@@ -94,7 +114,7 @@ export function PageResultsNew(_props: {}) {
                             direction={{ default: 'column' }}
                         >
                             <Card>
-                                <BuildInfo />
+                                <BuildInfo artifact={artifact} />
                             </Card>
                             <Card>
                                 <TestResultsTable

--- a/src/components/PageResultsNew/index.tsx
+++ b/src/components/PageResultsNew/index.tsx
@@ -24,8 +24,6 @@ import {
     Flex,
     PageSection,
     PageSectionVariants,
-    Stack,
-    StackItem,
 } from '@patternfly/react-core';
 import { useState } from 'react';
 
@@ -36,19 +34,21 @@ import './index.css';
 import { CiTest } from './types';
 import { SelectedTestContext } from './contexts';
 import { FAKE_TESTS } from './fakeData';
-import { BackButton, SummaryHeader } from './Header';
 import { TestResultsTable } from './TestResultsTable';
 import { BuildInfo } from './BuildInfo';
 import { DetailsDrawer } from './DetailsDrawer';
+import { ArtifactHeader } from './Header';
 
 export function PageResultsNew(_props: {}) {
     const [selectedTest, setSelectedTest] = useState<CiTest | undefined>();
 
-    const pageTitle = `New test results | ${config.defaultTitle}`;
+    const pageTitle = `🚧 New test results | ${config.defaultTitle}`;
 
     // TODO: Display real data.
     const buildNvr = 'ansible-collection-microsoft-sql-1.2.4-1.el9';
     const buildOwner = 'mgrabovs';
+    const gatingTag = 'rhel-8.7.0-build-sidetag-101738-stack-gate';
+    const taskId = 47942709;
 
     // TODO: Use unique key later on.
     const onTestSelect = (name: string | undefined) => {
@@ -66,20 +66,13 @@ export function PageResultsNew(_props: {}) {
             <SelectedTestContext.Provider value={selectedTest}>
                 <DetailsDrawer onClose={() => setSelectedTest(undefined)}>
                     <PageSection variant={PageSectionVariants.light}>
-                        <Stack className="resultsNarrower">
-                            <StackItem>
-                                <BackButton />
-                            </StackItem>
-                            <StackItem>
-                                {/* TODO: Display real data. */}
-                                <SummaryHeader
-                                    gatingStatus="fail"
-                                    gatingTag="rhel-8.7.0-build-sidetag-101738-stack-gate"
-                                    nvr={buildNvr}
-                                    owner={buildOwner}
-                                />
-                            </StackItem>
-                        </Stack>
+                        <ArtifactHeader
+                            gatingStatus="fail"
+                            gatingTag={gatingTag}
+                            nvr={buildNvr}
+                            owner={buildOwner}
+                            taskId={taskId}
+                        />
                     </PageSection>
                     <PageSection isFilled variant={PageSectionVariants.default}>
                         <Flex

--- a/src/components/PageResultsNew/types.ts
+++ b/src/components/PageResultsNew/types.ts
@@ -25,17 +25,18 @@ export type TestStatus =
     | 'passed'
     | 'queued'
     | 'running'
+    | 'unknown'
     | 'waived';
 
 export type TestCaseStatus = 'fail' | 'pass' | 'skip';
 
 export interface CiTest {
-    isWaivable?: boolean;
     labels?: string[];
     name: string;
     required?: boolean;
     status: TestStatus;
     subtitle?: string;
+    waivable?: boolean;
 }
 
 export interface TestCase {

--- a/src/custom.module.css
+++ b/src/custom.module.css
@@ -109,8 +109,8 @@ dl.buildInfo {
     row-gap: var(--pf-global--spacer--sm);
 }
 
-.buildInfoCommitHash,
-.buildInfoTimestamp {
+.commitHash,
+.timestamp {
     --pf-c-description-list__description--FontSize: 0.85em;
     font-size: 0.85em;
     font-family: monospace;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -103,7 +103,7 @@ export const otherRoutes: MenuEntry[] = [
          * - /artifact/:type/:field/:value/tc/:testcase - show specific test in sidebar
          * - /artifact/:type/:field/:value/...?
          */
-        to: '/resultsnew/:task_id?',
+        to: '/resultsnew/:aid?',
         render: (props) => <PageResultsNew {...props} />,
     },
 ];

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -97,7 +97,13 @@ export const otherRoutes: MenuEntry[] = [
     {
         title: '',
         key: 'resultsnew',
-        to: '/resultsnew',
+        /*
+         * Further details on new address structure:
+         * - /artifact/:type/:field/:value - same as now, see PageByMongoField
+         * - /artifact/:type/:field/:value/tc/:testcase - show specific test in sidebar
+         * - /artifact/:type/:field/:value/...?
+         */
+        to: '/resultsnew/:task_id?',
         render: (props) => <PageResultsNew {...props} />,
     },
 ];

--- a/src/utils/artifactUtils.tsx
+++ b/src/utils/artifactUtils.tsx
@@ -692,29 +692,43 @@ const SATISFIED_REQUIREMENT_TYPES: GreenwaveRequirementTypesType[] = [
     'test-result-passed',
 ];
 
+const isRequirementSatisfied = (state: StateGreenwaveType): boolean =>
+    _.includes(SATISFIED_REQUIREMENT_TYPES, state.requirement?.type);
+
 /**
  * Should we display a waive button for this result in the dashboard?
  * Show the button only if the test is blocking gating.
  * @param state The state object of the test result in question.
  */
-export const isResultWaivable = (state: StateGreenwaveType): boolean =>
-    !_.includes(SATISFIED_REQUIREMENT_TYPES, state.requirement?.type);
+export const isResultWaivable = (state: StateType): boolean => {
+    if (isGreenwaveKaiState(state)) return !isRequirementSatisfied(state.gs);
+    if (isGreenwaveState(state)) return !isRequirementSatisfied(state);
+    return false;
+};
+
+/**
+ * List of Greenwave requirement types that we consider as missing.
+ */
+const MISSING_REQUIREMENT_TYPES: GreenwaveRequirementTypesType[] = [
+    'missing-gating-yaml',
+    'missing-gating-yaml-waived',
+    'test-result-missing',
+    'test-result-missing-waived',
+];
+
+const isRequirementMissing = (state: StateGreenwaveType): boolean =>
+    _.includes(MISSING_REQUIREMENT_TYPES, state.requirement?.type);
 
 /**
  * Check if the Greenwave state is missing the required test result.
  * @param state The Greenwave state to check.
  * @returns `true` if the required result is missing in Greenwave, `false` otherwise.
  */
-export const isResultMissing = (state: StateGreenwaveType): boolean =>
-    _.includes(
-        [
-            'missing-gating-yaml',
-            'missing-gating-yaml-waived',
-            'test-result-missing',
-            'test-result-missing-waived',
-        ],
-        state.requirement?.type,
-    );
+export const isResultMissing = (state: StateType): boolean => {
+    if (isGreenwaveKaiState(state)) return isRequirementMissing(state.gs);
+    if (isGreenwaveState(state)) return isRequirementMissing(state);
+    return false;
+};
 
 export const timestampForUser = (
     timestamp: string,

--- a/src/utils/timeUtils.test.ts
+++ b/src/utils/timeUtils.test.ts
@@ -1,0 +1,39 @@
+/*
+ * This file is part of ciboard
+ *
+ * Copyright (c) 2023 Matěj Grabovský <mgrabovs@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { secondsToTimestampWithTz } from './timeUtils';
+
+test('zero time converts correctly', () => {
+    const unixTimestamp = 0;
+    const timestampWithTz = '1970-01-01 01:00 +0100';
+    expect(secondsToTimestampWithTz(unixTimestamp)).toEqual(timestampWithTz);
+});
+
+test('non-zero time converts correctly', () => {
+    const unixTimestamp = 1675159583;
+    const timestampWithTz = '2023-01-31 11:06 +0100';
+    expect(secondsToTimestampWithTz(unixTimestamp)).toEqual(timestampWithTz);
+});
+
+test('non-zero DST time converts correctly', () => {
+    const unixTimestamp = 1686719691;
+    const timestampWithTz = '2023-06-14 07:14 +0200';
+    expect(secondsToTimestampWithTz(unixTimestamp)).toEqual(timestampWithTz);
+});

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ciboard
+ *
+ * Copyright (c) 2021, 2022 Andrei Stepanov <astepano@redhat.com>
+ * Copyright (c) 2023 Matěj Grabovský <mgrabovs@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as moment from 'moment';
+
+const TIMESTAMP_WITH_TZ_FORMAT = 'YYYY-MM-DD HH:mm ZZ';
+
+/**
+ * Format a timestamp as a date and time with time zone offset.
+ * @param seconds Number of seconds since the Unix epoch.
+ * @returns Formatted timestamp as a string.
+ */
+export function secondsToTimestampWithTz(seconds: number) {
+    const localTime = moment.unix(seconds).local();
+    return localTime.format(TIMESTAMP_WITH_TZ_FORMAT);
+}


### PR DESCRIPTION
In this checkpoint, the page now shows real data for RPM builds:
- NVR, gating tag and gating status, build time, commit information, tags and tagging history, and related advisories;
- list of real test results in the results table (name and status only for now).

Reference: OSCI-4226