### PR TITLE
Fix link to RH MBS

### DIFF
--- a/src/config.tsx
+++ b/src/config.tsx
@@ -60,7 +60,7 @@ export const config = {
             webUrl: 'https://release-engineering.github.io/mbs-ui/',
         },
         rh: {
-            webUrl: 'https://mbsweb.engineering.redhat.com/',
+            webUrl: 'https://mbsweb.engineering.redhat.com/mbs-ui/',
         },
     },
     waiverdb: {


### PR DESCRIPTION
The link next to **Build ID** on modular artifact pages seems to be wrong. For example, on https://dashboard.osci.redhat.com/#/artifact/redhat-module/aid/21122, it links to https://mbsweb.engineering.redhat.com//module/21122 instead of https://mbsweb.engineering.redhat.com/mbs-ui/module/21122.

(Note that I haven't built the project but this looks correct to me.)